### PR TITLE
fix(TS): make container optional in RenderOptions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,7 +14,7 @@ export interface RenderResult extends GetsAndQueries {
 }
 
 export interface RenderOptions {
-  container: HTMLElement
+  container?: HTMLElement
   baseElement?: HTMLElement
   hydrate?: boolean
 }


### PR DESCRIPTION
**What**: TS: make container optional in RenderOptions

<!-- Why are these changes necessary? -->

**Why**: Particularly useful if you're making a custom render with custom options. If you extend the type and call your custom render without the container but with the other options then you get a false error.

<!-- How were these changes implemented? -->

**How**: `?`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
