### PR TITLE
fix: Specify baseElement without container

### DIFF
--- a/src/__tests__/multi-base.js
+++ b/src/__tests__/multi-base.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import {render, cleanup} from '../'
+
+// these are created once per test suite and reused for each case
+let treeA, treeB
+beforeAll(() => {
+  treeA = document.createElement('div')
+  treeB = document.createElement('div')
+  document.body.appendChild(treeA)
+  document.body.appendChild(treeB)
+})
+
+afterAll(() => {
+  treeA.parentNode.removeChild(treeA)
+  treeB.parentNode.removeChild(treeB)
+})
+
+afterEach(cleanup)
+
+test('baseElement isolates trees from one another', () => {
+  const {getByText: getByTextInA} = render(<div>Jekyll</div>, {
+    baseElement: treeA,
+  })
+  const {getByText: getByTextInB} = render(<div>Hyde</div>, {
+    baseElement: treeB,
+  })
+
+  expect(() => getByTextInA('Jekyll')).not.toThrow(
+    'Unable to find an element with the text: Jekyll.',
+  )
+  expect(() => getByTextInB('Jekyll')).toThrow(
+    'Unable to find an element with the text: Jekyll.',
+  )
+
+  expect(() => getByTextInA('Hyde')).toThrow(
+    'Unable to find an element with the text: Hyde.',
+  )
+  expect(() => getByTextInB('Hyde')).not.toThrow(
+    'Unable to find an element with the text: Hyde.',
+  )
+})

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -113,3 +113,44 @@ test('renders options.wrapper around node', () => {
 </div>
 `)
 })
+
+describe('baseElement', () => {
+  let baseElement
+  beforeAll(() => {
+    baseElement = document.createElement('div')
+    document.body.appendChild(baseElement)
+  })
+
+  afterAll(() => {
+    baseElement.parentNode.removeChild(baseElement)
+  })
+
+  it('can take a custom element for isolation', () => {
+    function DescribedButton({title: description, ...buttonProps}) {
+      return (
+        <React.Fragment>
+          <button {...buttonProps} aria-describedby="tooltip" />
+          {ReactDOM.createPortal(
+            <div id="tooltip" role="tooltip">
+              {description}
+            </div>,
+            document.body,
+          )}
+        </React.Fragment>
+      )
+    }
+
+    const {getByRole, getByText} = render(
+      <DescribedButton description="this descripton is hidden from rtl">
+        Click me
+      </DescribedButton>,
+      {baseElement},
+    )
+
+    expect(getByText('Click me')).toBeTruthy()
+    expect(document.querySelector('[role="tooltip"]')).toBeTruthy()
+    expect(() => getByRole('tooltip')).toThrow(
+      'Unable to find an element by [role=tooltip]',
+    )
+  })
+})

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -3,8 +3,6 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import {render, cleanup} from '../'
 
-afterEach(cleanup)
-
 test('renders div into document', () => {
   const ref = React.createRef()
   const {container} = render(<div ref={ref} />)
@@ -112,45 +110,4 @@ test('renders options.wrapper around node', () => {
   />
 </div>
 `)
-})
-
-describe('baseElement', () => {
-  let baseElement
-  beforeAll(() => {
-    baseElement = document.createElement('div')
-    document.body.appendChild(baseElement)
-  })
-
-  afterAll(() => {
-    baseElement.parentNode.removeChild(baseElement)
-  })
-
-  it('can take a custom element for isolation', () => {
-    function DescribedButton({title: description, ...buttonProps}) {
-      return (
-        <React.Fragment>
-          <button {...buttonProps} aria-describedby="tooltip" />
-          {ReactDOM.createPortal(
-            <div id="tooltip" role="tooltip">
-              {description}
-            </div>,
-            document.body,
-          )}
-        </React.Fragment>
-      )
-    }
-
-    const {getByRole, getByText} = render(
-      <DescribedButton description="this descripton is hidden from rtl">
-        Click me
-      </DescribedButton>,
-      {baseElement},
-    )
-
-    expect(getByText('Click me')).toBeTruthy()
-    expect(document.querySelector('[role="tooltip"]')).toBeTruthy()
-    expect(() => getByRole('tooltip')).toThrow(
-      'Unable to find an element by [role=tooltip]',
-    )
-  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,13 @@ function render(
     wrapper: WrapperComponent,
   } = {},
 ) {
-  if (!container) {
+  if (!baseElement) {
     // default to document.body instead of documentElement to avoid output of potentially-large
     // head elements (such as JSS style blocks) in debug output
     baseElement = document.body
-    container = document.body.appendChild(document.createElement('div'))
+  }
+  if (!container) {
+    container = baseElement.appendChild(document.createElement('div'))
   }
 
   // we'll add it to the mounted containers regardless of whether it's actually


### PR DESCRIPTION
**What**:

Fix `baseElement` being overridden if no `container` was provided

**Why**:

I'm having a hard time grasping the difference between `baseElement` and `container` in the current implementation:
> The containing DOM node where your React Element is rendered in the container.

-- https://testing-library.com/docs/react-testing-library/api#baseelement-1

Considering the default values I imagined it as 
```html
<base-element>
  <container>
    <Component />
  </container>
</base-element>
```

The `base-element` acts as a long living container that will hold every rendered container but can be isolated from the rest of the document.

What I'm basically trying to achieve is that the queries don't look inside document.body but rather only in the DOM tree rendered by the component. It's not so much about portals but other react trees living in the same document that should be ignored.

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) Note: Should I rather update the documentation?
- [x] Tests
- ~[ ] Typescript definitions updated~
- [ ] Ready to be merged Note: If this is indeed a bug, yes. Otherwise I repurpose this as a feature request

<!-- feel free to add additional comments -->
