### PR TITLE
fix(TS): use `Queries` from @testing-library/dom

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,20 +1,6 @@
-import {queries, BoundFunction} from '@testing-library/dom'
+import {queries, Queries, BoundFunction} from '@testing-library/dom'
 
 export * from '@testing-library/dom'
-
-interface Query extends Function {
-  (container: HTMLElement, ...args: any[]):
-    | Error
-    | Promise<HTMLElement[]>
-    | Promise<HTMLElement>
-    | HTMLElement[]
-    | HTMLElement
-    | null
-}
-
-export interface Queries {
-  [T: string]: Query
-}
 
 export type RenderResult<Q extends Queries = typeof queries> = {
   container: HTMLElement


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Delete duplicate `Query` and `Queries` declarations and reuse them from `@testing-library/dom` instead.

<!-- Why are these changes necessary? -->

**Why**: I mistakenly exported `Queries` interface when I shouldn't have in PR #396 - it was already being exported by `@testing-library/dom`. Also see https://github.com/testing-library/react-testing-library/pull/331#pullrequestreview-217309669. Apologies for the original PR!

<!-- How were these changes implemented? -->

**How**: Deleted duplicate declarations and tested locally against the latest versions of RTL/DTL.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
