### PR TITLE
tests: added i18next example

### DIFF
--- a/examples/__tests__/i18next.js
+++ b/examples/__tests__/i18next.js
@@ -1,0 +1,91 @@
+import React, {Fragment} from 'react'
+import {initReactI18next, I18nextProvider, Trans} from 'react-i18next'
+import i18n from 'i18next'
+import Backend from 'i18next-xhr-backend'
+import LanguageDetector from 'i18next-browser-languagedetector'
+import {render, cleanup, getByTestId, fireEvent} from 'react-testing-library'
+import 'jest-dom/extend-expect'
+
+const resources = {
+  en: {
+    translation: {
+      'Welcome to React': 'Welcome to React and react-i18next',
+    },
+  },
+  pt: {
+    translation: {
+      'Welcome to React': 'Bem vindo ao React e ao react-i18next',
+    },
+  },
+}
+
+i18n
+  .use(Backend)
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'en',
+    debug: false,
+    resources: {
+      en: resources.en,
+      pt: resources.pt,
+    },
+    interpolation: {
+      escapeValue: false, // not needed for react as it escapes by default
+    },
+  })
+
+const renderWithi18next = Component => {
+  let rerender = () => {}
+  const Comp = React.cloneElement(Component, {
+    changeLanguage: lng => {
+      i18n.changeLanguage(lng)
+      rerender(<I18nextProvider i18n={i18n}>{Comp}</I18nextProvider>)
+    },
+  })
+  const defaultRender = render(
+    <I18nextProvider i18n={i18n}>{Comp}</I18nextProvider>,
+  )
+  rerender = defaultRender.rerender
+  return defaultRender
+}
+
+const MainView = props => {
+  return (
+    <Fragment>
+      <div className="App-header">
+        <button
+          data-testid="pt-trans"
+          onClick={() => props.changeLanguage('pt')}
+        >
+          pt
+        </button>
+        <button
+          data-testid="en-trans"
+          onClick={() => props.changeLanguage('en')}
+        >
+          en
+        </button>
+      </div>
+      <h1 data-testid="text-trans">
+        <Trans>Welcome to React</Trans>
+      </h1>
+    </Fragment>
+  )
+}
+
+afterEach(cleanup)
+
+describe('lets make some tests', () => {
+  test('it should test lang', () => {
+    const {container} = renderWithi18next(<MainView />)
+    expect(getByTestId(container, 'text-trans')).toBeDefined()
+    expect(getByTestId(container, 'text-trans')).toHaveTextContent(
+      'Welcome to React and react-i18next',
+    )
+    fireEvent.click(getByTestId(container, 'pt-trans'))
+    expect(getByTestId(container, 'text-trans')).toHaveTextContent(
+      'Bem vindo ao React e ao react-i18next',
+    )
+  })
+})

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@testing-library/dom": "^5.0.0"
+    "@testing-library/dom": "^5.0.0",
+    "react-i18next": "^10.11.2"
   },
   "devDependencies": {
     "@reach/router": "^1.2.1",
@@ -52,6 +53,9 @@
     "eslint-import-resolver-jest": "^2.1.1",
     "history": "^4.9.0",
     "intl": "^1.2.5",
+    "i18next": "17.0.4",
+    "i18next-browser-languagedetector": "3.0.1",
+    "i18next-xhr-backend": "3.0.0",
     "jest-dom": "3.4.0",
     "jest-in-case": "^1.0.2",
     "kcd-scripts": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@testing-library/dom": "^5.0.0",
-    "react-i18next": "^10.11.2"
+    "@testing-library/dom": "^5.0.0"
   },
   "devDependencies": {
     "@reach/router": "^1.2.1",
@@ -62,6 +61,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-intl": "^2.9.0",
+    "react-i18next": "^10.11.2",
     "react-redux": "7.0.3",
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.0",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Adding i18Next example with locale

<!-- Why are these changes necessary? -->

**Why**: https://github.com/testing-library/react-testing-library/issues/390

<!-- How were these changes implemented? -->

**How**: I've put the logic to display to users how make test with locale in using i18next, I've create an example with a test.
Refs: 
https://react.i18next.com/misc/testing
https://codesandbox.io/s/testing-library-i18next-vot1o

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ X ] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Once this PR is accepted I'll updated the docs site.