### PR TITLE
await act(...) inside cleanup-after-each

### DIFF
--- a/cleanup-after-each.js
+++ b/cleanup-after-each.js
@@ -1,1 +1,3 @@
-afterEach(require('./dist').cleanup)
+afterEach(() => {
+  return require('./dist/cleanup-async')()
+})

--- a/src/__tests__/cleanup-after-each.js
+++ b/src/__tests__/cleanup-after-each.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import {render} from '../index'
+import cleanupAsync from '../cleanup-async'
+
+afterEach(() => {
+  return cleanupAsync()
+})
+
+const log = []
+let ctr = 0
+
+function App() {
+  async function somethingAsync() {
+    await null
+    log.push(ctr++)
+  }
+  React.useEffect(() => {
+    somethingAsync()
+  }, [])
+  return 123
+}
+
+it('cleanup-after-each does not leave any hanging microtasks: part 1', () => {
+  render(<App />)
+  expect(document.body.textContent).toBe('123')
+  expect(log).toEqual([])
+})
+
+it('cleanup-after-each does not leave any hanging microtasks: part 2', () => {
+  expect(log).toEqual([0])
+  expect(document.body.innerHTML).toBe('')
+})

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import {reactDomSixteenPointNineIsReleased} from './react-dom-16.9.0-is-released'
 import * as testUtils from 'react-dom/test-utils'
+import {reactDomSixteenPointNineIsReleased} from './react-dom-16.9.0-is-released'
 
 const reactAct = testUtils.act
 const actSupported = reactAct !== undefined

--- a/src/cleanup-async.js
+++ b/src/cleanup-async.js
@@ -1,0 +1,10 @@
+// This file is for use by the top-level export
+// @testing-library/react/cleanup-after-each
+// It is not meant to be used directly
+
+module.exports = async function cleanupAsync() {
+  const {asyncAct} = require('./act-compat')
+  const {cleanup} = require('./index')
+  await asyncAct(async () => {})
+  cleanup()
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This PR adds an async `act()` call to `cleanup-after-each`. 

<!-- Why are these changes necessary? -->

**Why**:

Tests, especially those with async logic, could have hanging microtasks or React work that could leak into the next test. 

<!-- How were these changes implemented? -->

**How**:

This PR
- adds `cleanup-after-each.js` (so I can write tests for it)
- awaits an `act(async () => {})` call before unmounting containers
- And a test for the same

**Some possible Q&A**:

- Why not do a sync `act()` in `cleanup()`?: If peeps are using react-testing-library, it's suuuper unlikely they'll have hanging sync effects/updates. Decided not to add code without a good reason.

(bonus: fixes a lint violation in act-compat.js)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs site](https://github.com/alexkrolick/testing-library-docs) - **NA**
- [x] Tests
- [x] Typescript definitions updated - **NA**
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
