### PR TITLE
feat(cleanup): automatically cleanup if afterEach is detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@testing-library/dom": "^5.6.1"
+    "@testing-library/dom": "^6.0.0"
   },
   "devDependencies": {
     "@reach/router": "^1.2.1",
     "@testing-library/jest-dom": "^4.0.0",
-    "@types/react": "^16.8.25",
+    "@types/react": "^16.9.1",
     "@types/react-dom": "^16.8.5",
     "kcd-scripts": "^1.5.2",
     "react": "^16.9.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "files": [
     "dist",
     "typings",
-    "cleanup-after-each.js"
+    "cleanup-after-each.js",
+    "pure.js"
   ],
   "keywords": [
     "testing",

--- a/pure.js
+++ b/pure.js
@@ -1,0 +1,2 @@
+// makes it so people can import from '@testing-library/react/pure'
+module.exports = require('./dist/pure')

--- a/src/__tests__/auto-cleanup-skip.js
+++ b/src/__tests__/auto-cleanup-skip.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+let render
+beforeAll(() => {
+  process.env.RTL_SKIP_CLEANUP = 'true'
+  const rtl = require('../')
+  render = rtl.render
+})
+
+// This one verifies that if RTL_SKIP_CLEANUP is set
+// that we DON'T auto-wire up the afterEach for folks
+test('first', () => {
+  render(<div>hi</div>)
+})
+
+test('second', () => {
+  expect(document.body.innerHTML).toEqual('<div><div>hi</div></div>')
+})

--- a/src/__tests__/auto-cleanup-skip.js
+++ b/src/__tests__/auto-cleanup-skip.js
@@ -8,7 +8,7 @@ beforeAll(() => {
 })
 
 // This one verifies that if RTL_SKIP_CLEANUP is set
-// that we DON'T auto-wire up the afterEach for folks
+// then we DON'T auto-wire up the afterEach for folks
 test('first', () => {
   render(<div>hi</div>)
 })

--- a/src/__tests__/auto-cleanup-skip.js
+++ b/src/__tests__/auto-cleanup-skip.js
@@ -2,12 +2,12 @@ import React from 'react'
 
 let render
 beforeAll(() => {
-  process.env.RTL_SKIP_CLEANUP = 'true'
+  process.env.RTL_SKIP_AUTO_CLEANUP = 'true'
   const rtl = require('../')
   render = rtl.render
 })
 
-// This one verifies that if RTL_SKIP_CLEANUP is set
+// This one verifies that if RTL_SKIP_AUTO_CLEANUP is set
 // then we DON'T auto-wire up the afterEach for folks
 test('first', () => {
   render(<div>hi</div>)

--- a/src/__tests__/auto-cleanup.js
+++ b/src/__tests__/auto-cleanup.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import {render} from '../'
+
+// This just verifies that by importing RTL in an
+// environment which supports afterEach (like jest)
+// we'll get automatic cleanup between tests.
+test('first', () => {
+  render(<div>hi</div>)
+})
+
+test('second', () => {
+  expect(document.body.innerHTML).toEqual('')
+})

--- a/src/index.js
+++ b/src/index.js
@@ -142,6 +142,16 @@ fireEvent.select = (node, init) => {
   fireEvent.keyUp(node, init)
 }
 
+// if we're running in a test runner that supports afterEach
+// then we'll automatically run cleanup afterEach test
+// this ensures that tests run in isolation from each other
+if (typeof afterEach === 'function' && !process.env.RTL_SKIP_CLEANUP) {
+  afterEach(async () => {
+    await asyncAct(async () => {})
+    cleanup()
+  })
+}
+
 // just re-export everything from dom-testing-library
 export * from '@testing-library/dom'
 export {render, cleanup, fireEvent, act}

--- a/src/index.js
+++ b/src/index.js
@@ -1,163 +1,16 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import {
-  getQueriesForElement,
-  prettyDOM,
-  fireEvent as dtlFireEvent,
-  configure as configureDTL,
-} from '@testing-library/dom'
-import act, {asyncAct} from './act-compat'
-
-configureDTL({
-  asyncWrapper: async cb => {
-    let result
-    await asyncAct(async () => {
-      result = await cb()
-    })
-    return result
-  },
-})
-
-const mountedContainers = new Set()
-
-function render(
-  ui,
-  {
-    container,
-    baseElement = container,
-    queries,
-    hydrate = false,
-    wrapper: WrapperComponent,
-  } = {},
-) {
-  if (!baseElement) {
-    // default to document.body instead of documentElement to avoid output of potentially-large
-    // head elements (such as JSS style blocks) in debug output
-    baseElement = document.body
-  }
-  if (!container) {
-    container = baseElement.appendChild(document.createElement('div'))
-  }
-
-  // we'll add it to the mounted containers regardless of whether it's actually
-  // added to document.body so the cleanup method works regardless of whether
-  // they're passing us a custom container or not.
-  mountedContainers.add(container)
-
-  const wrapUiIfNeeded = innerElement =>
-    WrapperComponent
-      ? React.createElement(WrapperComponent, null, innerElement)
-      : innerElement
-
-  act(() => {
-    if (hydrate) {
-      ReactDOM.hydrate(wrapUiIfNeeded(ui), container)
-    } else {
-      ReactDOM.render(wrapUiIfNeeded(ui), container)
-    }
-  })
-
-  return {
-    container,
-    baseElement,
-    // eslint-disable-next-line no-console
-    debug: (el = baseElement) => console.log(prettyDOM(el)),
-    unmount: () => ReactDOM.unmountComponentAtNode(container),
-    rerender: rerenderUi => {
-      render(wrapUiIfNeeded(rerenderUi), {container, baseElement})
-      // Intentionally do not return anything to avoid unnecessarily complicating the API.
-      // folks can use all the same utilities we return in the first place that are bound to the container
-    },
-    asFragment: () => {
-      /* istanbul ignore if (jsdom limitation) */
-      if (typeof document.createRange === 'function') {
-        return document
-          .createRange()
-          .createContextualFragment(container.innerHTML)
-      }
-
-      const template = document.createElement('template')
-      template.innerHTML = container.innerHTML
-      return template.content
-    },
-    ...getQueriesForElement(baseElement, queries),
-  }
-}
-
-function cleanup() {
-  mountedContainers.forEach(cleanupAtContainer)
-}
-
-// maybe one day we'll expose this (perhaps even as a utility returned by render).
-// but let's wait until someone asks for it.
-function cleanupAtContainer(container) {
-  ReactDOM.unmountComponentAtNode(container)
-  if (container.parentNode === document.body) {
-    document.body.removeChild(container)
-  }
-  mountedContainers.delete(container)
-}
-
-// react-testing-library's version of fireEvent will call
-// dom-testing-library's version of fireEvent wrapped inside
-// an "act" call so that after all event callbacks have been
-// been called, the resulting useEffect callbacks will also
-// be called.
-function fireEvent(...args) {
-  let returnValue
-  act(() => {
-    returnValue = dtlFireEvent(...args)
-  })
-  return returnValue
-}
-
-Object.keys(dtlFireEvent).forEach(key => {
-  fireEvent[key] = (...args) => {
-    let returnValue
-    act(() => {
-      returnValue = dtlFireEvent[key](...args)
-    })
-    return returnValue
-  }
-})
-
-// React event system tracks native mouseOver/mouseOut events for
-// running onMouseEnter/onMouseLeave handlers
-// @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/EnterLeaveEventPlugin.js#L24-L31
-fireEvent.mouseEnter = fireEvent.mouseOver
-fireEvent.mouseLeave = fireEvent.mouseOut
-
-fireEvent.select = (node, init) => {
-  // React tracks this event only on focused inputs
-  node.focus()
-
-  // React creates this event when one of the following native events happens
-  // - contextMenu
-  // - mouseUp
-  // - dragEnd
-  // - keyUp
-  // - keyDown
-  // so we can use any here
-  // @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/SelectEventPlugin.js#L203-L224
-  fireEvent.keyUp(node, init)
-}
+import {asyncAct} from './act-compat'
+import {cleanup} from './pure'
 
 // if we're running in a test runner that supports afterEach
 // then we'll automatically run cleanup afterEach test
 // this ensures that tests run in isolation from each other
-if (typeof afterEach === 'function' && !process.env.RTL_SKIP_CLEANUP) {
+// if you don't like this then either import the `pure` module
+// or set the RTL_SKIP_AUTO_CLEANUP env variable to 'true'.
+if (typeof afterEach === 'function' && !process.env.RTL_SKIP_AUTO_CLEANUP) {
   afterEach(async () => {
     await asyncAct(async () => {})
     cleanup()
   })
 }
 
-// just re-export everything from dom-testing-library
-export * from '@testing-library/dom'
-export {render, cleanup, fireEvent, act}
-
-// NOTE: we're not going to export asyncAct because that's our own compatibility
-// thing for people using react-dom@16.8.0. Anyone else doesn't need it and
-// people should just upgrade anyway.
-
-/* eslint func-name-matching:0 */
+export * from './pure'

--- a/src/pure.js
+++ b/src/pure.js
@@ -1,0 +1,153 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import {
+  getQueriesForElement,
+  prettyDOM,
+  fireEvent as dtlFireEvent,
+  configure as configureDTL,
+} from '@testing-library/dom'
+import act, {asyncAct} from './act-compat'
+
+configureDTL({
+  asyncWrapper: async cb => {
+    let result
+    await asyncAct(async () => {
+      result = await cb()
+    })
+    return result
+  },
+})
+
+const mountedContainers = new Set()
+
+function render(
+  ui,
+  {
+    container,
+    baseElement = container,
+    queries,
+    hydrate = false,
+    wrapper: WrapperComponent,
+  } = {},
+) {
+  if (!baseElement) {
+    // default to document.body instead of documentElement to avoid output of potentially-large
+    // head elements (such as JSS style blocks) in debug output
+    baseElement = document.body
+  }
+  if (!container) {
+    container = baseElement.appendChild(document.createElement('div'))
+  }
+
+  // we'll add it to the mounted containers regardless of whether it's actually
+  // added to document.body so the cleanup method works regardless of whether
+  // they're passing us a custom container or not.
+  mountedContainers.add(container)
+
+  const wrapUiIfNeeded = innerElement =>
+    WrapperComponent
+      ? React.createElement(WrapperComponent, null, innerElement)
+      : innerElement
+
+  act(() => {
+    if (hydrate) {
+      ReactDOM.hydrate(wrapUiIfNeeded(ui), container)
+    } else {
+      ReactDOM.render(wrapUiIfNeeded(ui), container)
+    }
+  })
+
+  return {
+    container,
+    baseElement,
+    // eslint-disable-next-line no-console
+    debug: (el = baseElement) => console.log(prettyDOM(el)),
+    unmount: () => ReactDOM.unmountComponentAtNode(container),
+    rerender: rerenderUi => {
+      render(wrapUiIfNeeded(rerenderUi), {container, baseElement})
+      // Intentionally do not return anything to avoid unnecessarily complicating the API.
+      // folks can use all the same utilities we return in the first place that are bound to the container
+    },
+    asFragment: () => {
+      /* istanbul ignore if (jsdom limitation) */
+      if (typeof document.createRange === 'function') {
+        return document
+          .createRange()
+          .createContextualFragment(container.innerHTML)
+      }
+
+      const template = document.createElement('template')
+      template.innerHTML = container.innerHTML
+      return template.content
+    },
+    ...getQueriesForElement(baseElement, queries),
+  }
+}
+
+function cleanup() {
+  mountedContainers.forEach(cleanupAtContainer)
+}
+
+// maybe one day we'll expose this (perhaps even as a utility returned by render).
+// but let's wait until someone asks for it.
+function cleanupAtContainer(container) {
+  ReactDOM.unmountComponentAtNode(container)
+  if (container.parentNode === document.body) {
+    document.body.removeChild(container)
+  }
+  mountedContainers.delete(container)
+}
+
+// react-testing-library's version of fireEvent will call
+// dom-testing-library's version of fireEvent wrapped inside
+// an "act" call so that after all event callbacks have been
+// been called, the resulting useEffect callbacks will also
+// be called.
+function fireEvent(...args) {
+  let returnValue
+  act(() => {
+    returnValue = dtlFireEvent(...args)
+  })
+  return returnValue
+}
+
+Object.keys(dtlFireEvent).forEach(key => {
+  fireEvent[key] = (...args) => {
+    let returnValue
+    act(() => {
+      returnValue = dtlFireEvent[key](...args)
+    })
+    return returnValue
+  }
+})
+
+// React event system tracks native mouseOver/mouseOut events for
+// running onMouseEnter/onMouseLeave handlers
+// @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/EnterLeaveEventPlugin.js#L24-L31
+fireEvent.mouseEnter = fireEvent.mouseOver
+fireEvent.mouseLeave = fireEvent.mouseOut
+
+fireEvent.select = (node, init) => {
+  // React tracks this event only on focused inputs
+  node.focus()
+
+  // React creates this event when one of the following native events happens
+  // - contextMenu
+  // - mouseUp
+  // - dragEnd
+  // - keyUp
+  // - keyDown
+  // so we can use any here
+  // @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/SelectEventPlugin.js#L203-L224
+  fireEvent.keyUp(node, init)
+}
+
+// just re-export everything from dom-testing-library
+export * from '@testing-library/dom'
+export {render, cleanup, fireEvent, act}
+
+// NOTE: we're not going to export asyncAct because that's our own compatibility
+// thing for people using react-dom@16.8.0. Anyone else doesn't need it and
+// people should just upgrade anyway.
+
+/* eslint func-name-matching:0 */

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,6 +1,1 @@
 import '@testing-library/jest-dom/extend-expect'
-
-afterEach(() => {
-  // have to do a dynamic import so we don't mess up jest mocking for old-act.js
-  require('../src').cleanup()
-})


### PR DESCRIPTION
**What**:

automatically call `cleanup` (with async act) if `afterEach` is detected.

**Why**:

Closes #428

This effectively means that 90% of users wont even have to know about `cleanup` at all. Which is a huge improvement.

**How**:

You can disable this with the `RTL_SKIP_CLEANUP` environment variable if you so choose, but it's recommended to have cleanup work this way.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) Let's get this reviewed/merged first, then we can start working on the docs.
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
