### PR TITLE
fix: improve warning so people know they can upgrade to 16.9.0 now

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,17 +41,17 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.5.4",
-    "@testing-library/dom": "^5.5.4"
+    "@babel/runtime": "^7.5.5",
+    "@testing-library/dom": "^5.6.1"
   },
   "devDependencies": {
     "@reach/router": "^1.2.1",
     "@testing-library/jest-dom": "^4.0.0",
-    "@types/react": "^16.8.23",
-    "@types/react-dom": "^16.8.4",
+    "@types/react": "^16.8.25",
+    "@types/react-dom": "^16.8.5",
     "kcd-scripts": "^1.5.2",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -10,10 +10,6 @@ afterEach(() => {
   console.error.mockRestore()
 })
 
-jest.mock('../react-dom-16.9.0-is-released', () => ({
-  reactDomSixteenPointNineIsReleased: true,
-}))
-
 jest.mock('react-dom/test-utils', () => ({
   act: cb => {
     cb()

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import * as testUtils from 'react-dom/test-utils'
-import {reactDomSixteenPointNineIsReleased} from './react-dom-16.9.0-is-released'
 
 const reactAct = testUtils.act
 const actSupported = reactAct !== undefined
@@ -28,6 +27,7 @@ function asyncAct(cb) {
         const originalConsoleError = console.error
         console.error = function error(...args) {
           /* if console.error fired *with that specific message* */
+          /* istanbul ignore next */
           if (
             args[0].indexOf(
               'Warning: Do not await the result of calling ReactTestUtils.act',
@@ -75,8 +75,8 @@ function asyncAct(cb) {
 
         if (isAsyncActSupported === false) {
           console.error = originalConsoleError
-          /* istanbul-ignore-next */
-          if (!youHaveBeenWarned && reactDomSixteenPointNineIsReleased) {
+          /* istanbul ignore next */
+          if (!youHaveBeenWarned) {
             // if act is supported and async act isn't and they're trying to use async
             // act, then they need to upgrade from 16.8 to 16.9.
             // This is a seemless upgrade, so we'll add a warning

--- a/src/react-dom-16.9.0-is-released.js
+++ b/src/react-dom-16.9.0-is-released.js
@@ -1,2 +1,0 @@
-// we don't want to warn until react-dom@16.9.0 is actually released
-export const reactDomSixteenPointNineIsReleased = false


### PR DESCRIPTION
**What**:

improve warning so people know they can upgrade to 16.9.0 now

**Why**:

Closes #281

**How**:

Removed the `src/react-dom-16.9.0-is-released.js` because it's released now! Update the tests to not mock that module because it's no longer needed.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
