### PR TITLE
feat: add dont-cleanup-after-each.js

### DIFF
--- a/dont-cleanup-after-each.js
+++ b/dont-cleanup-after-each.js
@@ -1,0 +1,1 @@
+process.env.RTL_SKIP_AUTO_CLEANUP = true

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dist",
     "typings",
     "cleanup-after-each.js",
+    "dont-cleanup-after-each.js",
     "pure.js"
   ],
   "keywords": [


### PR DESCRIPTION
**What**: add dont-cleanup-after-each.js

**Why**:

This makes it easier for folks who don't want to write their tests in an isolated way. It's totally not recommended, but it will hopefully reduce pain while people migrate from one testing style to another.


**How**:

This is just a simple file that sets the RTL_SKIP_AUTO_CLEANUP environment variable so that RTL doesn't setup automatic cleanup. 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) [done](https://github.com/testing-library/testing-library-docs/pull/215)
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I decided to do this after reading https://github.com/testing-library/react-testing-library/pull/430#issuecomment-520142114