### PR TITLE
fix: Act type

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@testing-library/dom": "^6.0.0"
+    "@testing-library/dom": "^6.0.0",
+    "@types/react-dom": "*"
   },
   "devDependencies": {
     "@reach/router": "^1.2.1",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,5 @@
 import {queries, Queries, BoundFunction} from '@testing-library/dom'
+import {act as reactAct} from 'react-dom/test-utils'
 
 export * from '@testing-library/dom'
 
@@ -43,4 +44,6 @@ export function cleanup(): void
  * If that's not available (older version of react) then it
  * simply calls the given callback immediately
  */
-export function act(callback: () => void): void
+export const act: typeof reactAct extends () => any
+  ? typeof reactAct
+  : (callback: () => void) => void

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,6 +44,6 @@ export function cleanup(): void
  * If that's not available (older version of react) then it
  * simply calls the given callback immediately
  */
-export const act: typeof reactAct extends () => any
-  ? typeof reactAct
-  : (callback: () => void) => void
+export const act: typeof reactAct extends undefined
+  ? (callback: () => void) => void
+  : typeof reactAct


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes #436 by putting maintenance burden for `act` types on `@types/react-dom`. async `act` will be supported once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37554 is merged.

**Why**:

If act is exported from `react-dom/test-utils` we export it as well. The types should reflect that.

**How**:

Conditional types

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)~
- [x] Tests: tested locally by linking package. types from `react-dom/test-utils` are picked up properly.
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
