### PR TITLE
RFC - manually flush microtasks in afterEach

### DIFF
--- a/src/flush-microtasks.js
+++ b/src/flush-microtasks.js
@@ -1,3 +1,7 @@
+/* istanbul ignore file */
+// the part of this file that we need tested is definitely being run
+// and the part that is not cannot easily have useful tests written
+// anyway. So we're just going to ignore coverage for this file
 /**
  * copied from React's enqueueTask.js
  */

--- a/src/flush-microtasks.js
+++ b/src/flush-microtasks.js
@@ -1,0 +1,43 @@
+/**
+ * copied from React's enqueueTask.js
+ */
+
+let didWarnAboutMessageChannel = false
+let enqueueTask
+try {
+  // read require off the module object to get around the bundlers.
+  // we don't want them to detect a require and bundle a Node polyfill.
+  const requireString = `require${Math.random()}`.slice(0, 7)
+  const nodeRequire = module && module[requireString]
+  // assuming we're in node, let's try to get node's
+  // version of setImmediate, bypassing fake timers if any.
+  enqueueTask = nodeRequire('timers').setImmediate
+} catch (_err) {
+  // we're in a browser
+  // we can't use regular timers because they may still be faked
+  // so we try MessageChannel+postMessage instead
+  enqueueTask = callback => {
+    if (didWarnAboutMessageChannel === false) {
+      didWarnAboutMessageChannel = true
+      // eslint-disable-next-line no-console
+      console.error(
+        typeof MessageChannel !== 'undefined',
+        'This browser does not have a MessageChannel implementation, ' +
+          'so enqueuing tasks via await act(async () => ...) will fail. ' +
+          'Please file an issue at https://github.com/facebook/react/issues ' +
+          'if you encounter this warning.',
+      )
+    }
+    const channel = new MessageChannel()
+    channel.port1.onmessage = callback
+    channel.port2.postMessage(undefined)
+  }
+}
+
+export default function flushMicroTasks() {
+  return {
+    then(resolve) {
+      enqueueTask(resolve)
+    },
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {asyncAct} from './act-compat'
+import flush from './flush-microtasks'
 import {cleanup} from './pure'
 
 // if we're running in a test runner that supports afterEach
@@ -8,7 +8,7 @@ import {cleanup} from './pure'
 // or set the RTL_SKIP_AUTO_CLEANUP env variable to 'true'.
 if (typeof afterEach === 'function' && !process.env.RTL_SKIP_AUTO_CLEANUP) {
   afterEach(async () => {
-    await asyncAct(async () => {})
+    await flush()
     cleanup()
   })
 }


### PR DESCRIPTION
This PR replaces calling async act() in afterEach, with a version that still flushes microtasks, but doesn't wrap with act().

Explanation: If there are any hanging microtasks, that means a test ran without asserting on a valid state. Any async portion that causes updates should be asserted on, or atleast resolved within the scope of a test. This PR should still fire missing act warnings for a test, but won't let it leak to the next one.

