### PR TITLE
fix: spread console error args when proxying

### DIFF
--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -34,9 +34,7 @@ test('async act works even when the act is an old one', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
         Array [
           Array [
-            Array [
-              "sigil",
-            ],
+            "sigil",
           ],
           Array [
             "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -42,7 +42,7 @@ function asyncAct(cb) {
           ) {
             // no-op
           } else {
-            originalConsoleError.call(console, args)
+            originalConsoleError.call(console, ...args)
           }
         }
         let cbReturn, result

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -42,7 +42,7 @@ function asyncAct(cb) {
           ) {
             // no-op
           } else {
-            originalConsoleError.call(console, ...args)
+            originalConsoleError.apply(console, args)
           }
         }
         let cbReturn, result


### PR DESCRIPTION
**What**: This is a bug fix to ensure proxied `console.error` calls are passed through correctly.

**Why**: Without them, `console.log('Value:', 1)` would get logged as `['Value:', 1]` instead of `Value: 1`.

**How**: I'm not sure how this applies.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
