### PR TITLE
fix: eslint jest/no-if in rerender test

### DIFF
--- a/src/__tests__/rerender.js
+++ b/src/__tests__/rerender.js
@@ -10,23 +10,22 @@ test('rerender will re-render the element', () => {
 })
 
 test('hydrate will not update props until next render', () => {
-  const initial = '<input />'
+  const initialInputElement = document.createElement('input')
+  const container = document.createElement('div')
+  container.appendChild(initialInputElement)
+  document.body.appendChild(container)
 
-  const container = document.body.appendChild(document.createElement('div'))
-  container.innerHTML = initial
-  const input = container.querySelector('input')
   const firstValue = 'hello'
+  initialInputElement.value = firstValue
 
-  if (!input) throw new Error('No element')
-  input.value = firstValue
   const {rerender} = render(<input value="" onChange={() => null} />, {
     container,
     hydrate: true,
   })
 
-  const secondValue = 'goodbye'
+  expect(initialInputElement.value).toBe(firstValue)
 
-  expect(input.value).toBe(firstValue)
+  const secondValue = 'goodbye'
   rerender(<input value={secondValue} onChange={() => null} />)
-  expect(input.value).toBe(secondValue)
+  expect(initialInputElement.value).toBe(secondValue)
 })


### PR DESCRIPTION
**What**:
This PR fixes issue: #464 by writing the test slightly different so no if statement is needed anymore

**Why**:
Validation step is currently failing because of the eslint rule: jest/no-if.

**How**:
Not doing a querySelector and checking if it found the initial input element anymore, but actually creating these elements so no queryselector is needed anymore

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~~Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)~~
- [x] Tests
- [ ] ~~Typescript definitions updated~~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
