### PR TITLE
add type checking to asyncAct args

### DIFF
--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -98,4 +98,22 @@ test('async act recovers from sync errors', async () => {
   `)
 })
 
+test('async act handles values that are not strings', async () => {
+  try {
+    await asyncAct(() => {
+      throw new Error({error: 'test error'})
+    })
+  } catch (err) {
+    console.error('call console.error')
+  }
+  expect(console.error).toHaveBeenCalledTimes(1)
+  expect(console.error.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "call console.error",
+      ],
+    ]
+  `)
+})
+
 /* eslint no-console:0 */

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -97,13 +97,14 @@ test('async act recovers from sync errors', async () => {
 
 test('async act handles values that are not strings', async () => {
   try {
-    await asyncAct(() => {
+    await asyncAct(async () => {
       console.error({message: 'some message'})
+      await null
     })
   } catch (err) {
     console.error('call console.error')
   }
-  expect(console.error).toHaveBeenCalledTimes(3)
+  expect(console.error).toHaveBeenCalledTimes(2)
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
@@ -113,9 +114,6 @@ test('async act handles values that are not strings', async () => {
       ],
       Array [
         "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
-      ],
-      Array [
-        "call console.error",
       ],
     ]
   `)

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -32,18 +32,15 @@ test('async act works even when the act is an old one', async () => {
     console.error('sigil')
   })
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "sigil",
-          ],
-          Array [
-            "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
-          ],
-          Array [
-            "sigil",
-          ],
-        ]
-    `)
+    Array [
+      Array [
+        "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
+      ],
+      Array [
+        "sigil",
+      ],
+    ]
+  `)
   expect(callback).toHaveBeenCalledTimes(1)
 
   // and it doesn't warn you twice
@@ -101,14 +98,22 @@ test('async act recovers from sync errors', async () => {
 test('async act handles values that are not strings', async () => {
   try {
     await asyncAct(() => {
-      throw new Error({error: 'test error'})
+      console.error({message: 'some message'})
     })
   } catch (err) {
     console.error('call console.error')
   }
-  expect(console.error).toHaveBeenCalledTimes(1)
+  expect(console.error).toHaveBeenCalledTimes(3)
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
+      Array [
+        Object {
+          "message": "some message",
+        },
+      ],
+      Array [
+        "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
+      ],
       Array [
         "call console.error",
       ],

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -28,21 +28,23 @@ function asyncAct(cb) {
         console.error = function error(...args) {
           /* if console.error fired *with that specific message* */
           /* istanbul ignore next */
-          if (
-            args[0].indexOf(
-              'Warning: Do not await the result of calling ReactTestUtils.act',
-            ) === 0
-          ) {
-            // v16.8.6
-            isAsyncActSupported = false
-          } else if (
-            args[0].indexOf(
-              'Warning: The callback passed to ReactTestUtils.act(...) function must not return anything',
-            ) === 0
-          ) {
-            // no-op
-          } else {
-            originalConsoleError.apply(console, args)
+          if (typeof args[0] === 'string') {
+            if (
+              args[0].indexOf(
+                'Warning: Do not await the result of calling ReactTestUtils.act',
+              ) === 0
+            ) {
+              // v16.8.6
+              isAsyncActSupported = false
+            } else if (
+              args[0].indexOf(
+                'Warning: The callback passed to ReactTestUtils.act(...) function must not return anything',
+              ) === 0
+            ) {
+              // no-op
+            } else {
+              originalConsoleError.apply(console, args)
+            }
           }
         }
         let cbReturn, result

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -42,9 +42,9 @@ function asyncAct(cb) {
               ) === 0
             ) {
               // no-op
-            } else {
-              originalConsoleError.apply(console, args)
             }
+          } else {
+            originalConsoleError.apply(console, args)
           }
         }
         let cbReturn, result


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This PR fixes issue: #442  by adding type checking for args used in asyncAct function.
<!-- Why are these changes necessary? -->
**Why**:
Current implementation assumes console.erorr was always called with a string even though it could be called with other types.

<!-- How were these changes implemented? -->
**How**:
Wrapped execution of code in a type check if statement to ensure operations are done only on string types.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
