### PR TITLE
fix: console.error doesn't have to be a string in act.compat.js

### DIFF
--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -99,14 +99,11 @@ test('async act recovers from sync errors', async () => {
 })
 
 test('async act can handle any sort of console.error', async () => {
-  try {
-    await asyncAct(async () => {
-      console.error({error: 'some error'})
-      await null
-    })
-  } catch (err) {
-    console.log(err)
-  }
+  await asyncAct(async () => {
+    console.error({error: 'some error'})
+    await null
+  })
+
   expect(console.error).toHaveBeenCalledTimes(2)
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -98,4 +98,28 @@ test('async act recovers from sync errors', async () => {
   `)
 })
 
+test('async act can handle any sort of console.error', async () => {
+  try {
+    await asyncAct(async () => {
+      console.error({error: 'some error'})
+      await null
+    })
+  } catch (err) {
+    console.log(err)
+  }
+  expect(console.error).toHaveBeenCalledTimes(2)
+  expect(console.error.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "error": "some error",
+        },
+      ],
+      Array [
+        "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
+      ],
+    ]
+  `)
+})
+
 /* eslint no-console:0 */

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -119,4 +119,24 @@ test('async act can handle any sort of console.error', async () => {
   `)
 })
 
+test('async act should not show an error when ReactTestUtils.act returns something', async () => {
+  jest.resetModules()
+  jest.mock('react-dom/test-utils', () => ({
+    act: () => {
+      return new Promise(resolve => {
+        console.error(
+          'Warning: The callback passed to ReactTestUtils.act(...) function must not return anything',
+        )
+        resolve()
+      })
+    },
+  }))
+  asyncAct = require('../act-compat').asyncAct
+  await asyncAct(async () => {
+    await null
+  })
+
+  expect(console.error).toHaveBeenCalledTimes(0)
+})
+
 /* eslint no-console:0 */

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -28,7 +28,9 @@ function asyncAct(cb) {
         console.error = function error(...args) {
           /* if console.error fired *with that specific message* */
           /* istanbul ignore next */
+          const firstArgIsString = typeof args[0] === 'string'
           if (
+            firstArgIsString &&
             args[0].indexOf(
               'Warning: Do not await the result of calling ReactTestUtils.act',
             ) === 0
@@ -36,6 +38,7 @@ function asyncAct(cb) {
             // v16.8.6
             isAsyncActSupported = false
           } else if (
+            firstArgIsString &&
             args[0].indexOf(
               'Warning: The callback passed to ReactTestUtils.act(...) function must not return anything',
             ) === 0


### PR DESCRIPTION
What:
This PR fixes issue: #442 by adding type checking for args used in asyncAct function.

Why:
Current implementation assumes console.erorr was always called with a string even though it could be called with other types.

How:
Wrapped execution of code in a type check if statement to ensure operations are done only on string types.

Checklist:

- [ ]  Documentation added to the docs site N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
