### PR TITLE
feat: add pure bundle build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "node": ">=8"
   },
   "scripts": {
-    "build": "kcd-scripts build && kcd-scripts build --bundle --no-clean",
+    "prebuild": "rimraf dist",
+    "build": "npm-run-all --parallel build:main build:bundle:main build:bundle:pure",
+    "build:main": "kcd-scripts build --no-clean",
+    "build:bundle:main": "kcd-scripts build --bundle --no-clean",
+    "build:bundle:pure": "cross-env BUILD_FILENAME_SUFFIX=.pure BUILD_INPUT=src/pure.js kcd-scripts build --bundle --no-clean",
     "lint": "kcd-scripts lint",
     "test": "kcd-scripts test",
     "test:update": "npm test -- --updateSnapshot --coverage",
@@ -48,9 +52,12 @@
   "devDependencies": {
     "@reach/router": "^1.2.1",
     "@testing-library/jest-dom": "^4.1.0",
+    "cross-env": "^6.0.0",
     "kcd-scripts": "^1.7.0",
+    "npm-run-all": "^4.1.5",
     "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react-dom": "^16.9.0",
+    "rimraf": "^3.0.0"
   },
   "peerDependencies": {
     "react": "*",


### PR DESCRIPTION
**What**: Adds a "pure" build for bundling with rollup (and parallelizes all build scripts)

**Why**: Closes #486

**How**: Used the environment variables supported by the kcd-scripts rollup config: https://github.com/kentcdodds/kcd-scripts/blob/bd3c762c0202ac3564bb6a329e3e9e972795b5e7/src/config/rollup.config.js so we can make the pure.js file an entry and set the output filename suffix (so it doesn't overwrite the existing build).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A. I don't think the UMD is something we really document or need to honestly.
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->