### PR TITLE
feat(debug): allow debugging an array of containers

### DIFF
--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -19,4 +19,21 @@ test('debug pretty prints the container', () => {
   )
 })
 
+test('debug pretty prints multiple containers', () => {
+  const HelloWorld = () => (
+    <>
+      <h1 data-testid="testId">Hello World</h1>
+      <h1 data-testid="testId">Hello World</h1>
+    </>
+  )
+  const {getAllByTestId, debug} = render(<HelloWorld />)
+  const multipleElements = getAllByTestId('testId')
+  debug(multipleElements)
+
+  expect(console.log).toHaveBeenCalledTimes(2)
+  expect(console.log).toHaveBeenCalledWith(
+    expect.stringContaining('Hello World'),
+  )
+})
+
 /* eslint no-console:0 */

--- a/src/pure.js
+++ b/src/pure.js
@@ -60,8 +60,12 @@ function render(
   return {
     container,
     baseElement,
-    // eslint-disable-next-line no-console
-    debug: (el = baseElement) => console.log(prettyDOM(el)),
+    debug: (el = baseElement) =>
+      Array.isArray(el)
+        ? // eslint-disable-next-line no-console
+          el.forEach(e => console.log(prettyDOM(e)))
+        : // eslint-disable-next-line no-console,
+          console.log(prettyDOM(el)),
     unmount: () => ReactDOM.unmountComponentAtNode(container),
     rerender: rerenderUi => {
       render(wrapUiIfNeeded(rerenderUi), {container, baseElement})


### PR DESCRIPTION
**What**: 
Adds the ability to log an array of containers.

**Why**:
Right now, if you try to debug the output of a queryAll or getAll, you will receive an error. This will allow everyone to see the output of each container inside of the output of that query.

**How**:
Checks if the received container is an array, if so, logs each element of it.
 
**Checklist**:
- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged