### PR TITLE
chore(ci): add cron job install script for smoke testing next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,12 @@ node_js:
   - '8'
   - '10'
   - '12'
-install: npm install
+install:
+  - npm install
+  # as requested by the React team :)
+  # https://reactjs.org/blog/2019/10/22/react-release-channels.html#using-the-next-channel-for-integration-testing
+  - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then npm install react@next
+    react-dom@next; fi
 script: npm run validate
 after_success: kcd-scripts travis-after-success
 branches:


### PR DESCRIPTION
**What**: Test react's `next` versions

**Why**: https://reactjs.org/blog/2019/10/22/react-release-channels.html#using-the-next-channel-for-integration-testing

**How**: added a step to the install in our `.travis.yml` which will upgrade react and react-dom to the `next` release if we're running the cron job.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
