### PR TITLE
feat: Add option to render concurrent roots

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "cross-env": "^6.0.0",
     "kcd-scripts": "^1.7.0",
     "npm-run-all": "^4.1.5",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
+    "react": "^0.0.0-experimental-f6b8d31a7",
+    "react-dom": "^0.0.0-experimental-f6b8d31a7",
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {

--- a/src/__tests__/concurrent.js
+++ b/src/__tests__/concurrent.js
@@ -7,20 +7,18 @@ test('simple render works like legacy', () => {
   expect(container).toHaveTextContent('test')
 })
 
-test('unmount calls back  after commit', () => {
+test('unmounts are flushed in sync', () => {
   const {container, unmount} = render(<div>test</div>, {root: 'concurrent'})
 
-  unmount(() => {
-    expect(container.children).toHaveLength(0)
-  })
-  expect(container.children).toHaveLength(1)
+  unmount()
+
+  expect(container.children).toHaveLength(0)
 })
 
-test('rerender calls back after commit', () => {
+test('rerender are flushed in sync', () => {
   const {container, rerender} = render(<div>foo</div>, {root: 'concurrent'})
 
-  rerender(<div>bar</div>, () => {
-    expect(container).toHaveTextContent('bar')
-  })
+  rerender(<div>bar</div>)
+
   expect(container).toHaveTextContent('foo')
 })

--- a/src/__tests__/concurrent.js
+++ b/src/__tests__/concurrent.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {render, cleanup} from '../'
+import {act, render, cleanup} from '../'
 
 test('simple render works like legacy', () => {
   const {container} = render(<div>test</div>, {root: 'concurrent'})
@@ -29,4 +29,24 @@ test('cleanup unmounts in sync', () => {
   cleanup()
 
   expect(container.children).toHaveLength(0)
+})
+
+test('state updates are concurrent', () => {
+  function TrackingButton() {
+    const [clickCount, increment] = React.useReducer(n => n + 1, 0)
+
+    return (
+      <button type="button" onClick={increment}>
+        Clicked {clickCount} times.
+      </button>
+    )
+  }
+  const {getByRole} = render(<TrackingButton />, {root: 'concurrent'})
+
+  act(() => {
+    getByRole('button').click()
+    expect(getByRole('button')).toHaveTextContent('Clicked 0 times')
+  })
+
+  expect(getByRole('button')).toHaveTextContent('Clicked 1 times')
 })

--- a/src/__tests__/concurrent.js
+++ b/src/__tests__/concurrent.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {render} from '../'
+import {render, cleanup} from '../'
 
 test('simple render works like legacy', () => {
   const {container} = render(<div>test</div>, {root: 'concurrent'})
@@ -21,4 +21,12 @@ test('rerender are flushed in sync', () => {
   rerender(<div>bar</div>)
 
   expect(container).toHaveTextContent('foo')
+})
+
+test('cleanup unmounts in sync', () => {
+  const {container} = render(<div>test</div>, {root: 'concurrent'})
+
+  cleanup()
+
+  expect(container.children).toHaveLength(0)
 })

--- a/src/__tests__/concurrent.js
+++ b/src/__tests__/concurrent.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import {render} from '../'
+
+test('simple render works like legacy', () => {
+  const {container} = render(<div>test</div>, {root: 'concurrent'})
+
+  expect(container).toHaveTextContent('test')
+})
+
+test('unmount calls back  after commit', () => {
+  const {container, unmount} = render(<div>test</div>, {root: 'concurrent'})
+
+  unmount(() => {
+    expect(container.children).toHaveLength(0)
+  })
+  expect(container.children).toHaveLength(1)
+})
+
+test('rerender calls back after commit', () => {
+  const {container, rerender} = render(<div>foo</div>, {root: 'concurrent'})
+
+  rerender(<div>bar</div>, () => {
+    expect(container).toHaveTextContent('bar')
+  })
+  expect(container).toHaveTextContent('foo')
+})

--- a/src/pure.js
+++ b/src/pure.js
@@ -79,20 +79,22 @@ function render(
           el.forEach(e => console.log(prettyDOM(e)))
         : // eslint-disable-next-line no-console,
           console.log(prettyDOM(el)),
-    unmount: callback => {
+    unmount: () => {
       if (reactRoot) {
-        reactRoot.unmount(callback)
+        act(() => {
+          reactRoot.unmount()
+        })
       } else {
         ReactDOM.unmountComponentAtNode(container)
       }
     },
-    rerender: (rerenderUi, callback) => {
+    rerender: rerenderUi => {
       if (reactRoot === null) {
         render(wrapUiIfNeeded(rerenderUi), {container, baseElement})
         // Intentionally do not return anything to avoid unnecessarily complicating the API.
         // folks can use all the same utilities we return in the first place that are bound to the container
       } else {
-        reactRoot.render(wrapUiIfNeeded(rerenderUi), callback)
+        reactRoot.render(wrapUiIfNeeded(rerenderUi))
       }
     },
     asFragment: () => {

--- a/src/pure.js
+++ b/src/pure.js
@@ -124,7 +124,9 @@ function cleanupAtContainer(container) {
   if (reactRoot === undefined) {
     ReactDOM.unmountComponentAtNode(container)
   } else {
-    reactRoot.unmount()
+    act(() => {
+      reactRoot.unmount()
+    })
   }
 
   if (container.parentNode === document.body) {

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom/extend-expect'
+jest.mock('scheduler', () => require('scheduler/unstable_mock'))

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,2 +1,3 @@
 import '@testing-library/jest-dom/extend-expect'
+// eslint-disable-next-line import/no-extraneous-dependencies
 jest.mock('scheduler', () => require('scheduler/unstable_mock'))


### PR DESCRIPTION
First draft. There's a lot to figure out (like error message if the experimental build isn't used or if this cleanup is correct etc) 

**What**:

Adds `root` option to `render` which currently only allows `concurrent` but could be used to create blocking roots instead

**Why**:

hype-driven-development

**How**:

Added a lot of branching logic but overall the implementation would be simpler with `create*Root`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
