### PR TITLE
feat: Flush microtasks in cleanup

### DIFF
--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {render, cleanup} from '../'
 
-test('cleans up the document', () => {
+test('cleans up the document', async () => {
   const spy = jest.fn()
   const divId = 'my-div'
 
@@ -17,12 +17,12 @@ test('cleans up the document', () => {
   }
 
   render(<Test />)
-  cleanup()
+  await cleanup()
   expect(document.body.innerHTML).toBe('')
   expect(spy).toHaveBeenCalledTimes(1)
 })
 
-test('cleanup does not error when an element is not a child', () => {
+test('cleanup does not error when an element is not a child', async () => {
   render(<div />, {container: document.createElement('div')})
-  cleanup()
+  await cleanup()
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import flush from './flush-microtasks'
 import {cleanup} from './pure'
 
 // if we're running in a test runner that supports afterEach
@@ -8,8 +7,7 @@ import {cleanup} from './pure'
 // or set the RTL_SKIP_AUTO_CLEANUP env variable to 'true'.
 if (typeof afterEach === 'function' && !process.env.RTL_SKIP_AUTO_CLEANUP) {
   afterEach(async () => {
-    await flush()
-    cleanup()
+    await cleanup()
   })
 }
 

--- a/src/pure.js
+++ b/src/pure.js
@@ -7,6 +7,7 @@ import {
   configure as configureDTL,
 } from '@testing-library/dom'
 import act, {asyncAct} from './act-compat'
+import flush from './flush-microtasks'
 
 configureDTL({
   asyncWrapper: async cb => {
@@ -88,7 +89,8 @@ function render(
   }
 }
 
-function cleanup() {
+async function cleanup() {
+  await flush();
   mountedContainers.forEach(cleanupAtContainer)
 }
 


### PR DESCRIPTION
BREAKING:

`cleanup` is now async.

```diff
- cleanup();
+ await cleanup();
```

**What**:

Flushes microtasks (introduced in #514) in cleanup instead of afterEach

**Why**:

Flushing microtask is not available for users of the `/pure` build.

**How**:

Move logic from index#afterEach into pure#cleanup

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
