### PR TITLE
fix: False positive warning about MessageChannel

### DIFF
--- a/src/flush-microtasks.js
+++ b/src/flush-microtasks.js
@@ -21,20 +21,22 @@ try {
   // we can't use regular timers because they may still be faked
   // so we try MessageChannel+postMessage instead
   enqueueTask = callback => {
-    if (didWarnAboutMessageChannel === false) {
+    const supportsMessageChannel = typeof MessageChannel === 'function'
+    if (supportsMessageChannel) {
+      const channel = new MessageChannel()
+      channel.port1.onmessage = callback
+      channel.port2.postMessage(undefined)
+    } else if (didWarnAboutMessageChannel === false) {
       didWarnAboutMessageChannel = true
+
       // eslint-disable-next-line no-console
       console.error(
-        typeof MessageChannel !== 'undefined',
         'This browser does not have a MessageChannel implementation, ' +
           'so enqueuing tasks via await act(async () => ...) will fail. ' +
           'Please file an issue at https://github.com/facebook/react/issues ' +
           'if you encounter this warning.',
       )
     }
-    const channel = new MessageChannel()
-    channel.port1.onmessage = callback
-    channel.port2.postMessage(undefined)
   }
 }
 


### PR DESCRIPTION
**What**:
Closes #521 

**Why**:

Warning was a false positive

**How**:

Correctly translate 

```js
warningWithoutStack(
          typeof MessageChannel !== 'undefined',
          'This browser does not have a MessageChannel implementation, ' +
            'so enqueuing tasks via await act(async () => ...) will fail. ' +
            'Please file an issue at https://github.com/facebook/react/issues ' +
            'if you encounter this warning.',
        );
```

`warningWithoutStack` (like [`warning`](https://www.npmjs.com/package/warning)) works different than `console.error` and is very confusing (which is also why react is getting rid of it)

**Checklist**:
check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [x] Tests: Tested with https://github.com/mui-org/material-ui/pull/18183/commits/9e6a0298df15b603d9bd9bef60a2ad042291fd19 which should report green in https://app.circleci.com/jobs/github/mui-org/material-ui/124966
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
