### PR TITLE
fix: support automatic types in pnpm installs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export * from 'testing-library__react'


### PR DESCRIPTION
When installed with pnpm, the `@types/testing-library__react` package cannot be used by packages that don't directly depend on it, so we need to re-export them.