### PR TITLE
Fix error on complex example

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ function Login() {
         </div>
         <button type="submit">Submit{state.loading ? '...' : null}</button>
       </form>
-      {state.error ? <div role="alert">{state.error.message}</div> : null}
+      {state.error ? <div role="alert">{state.error}</div> : null}
       {state.resolved ? (
         <div role="alert">Congrats! You're signed in!</div>
       ) : null}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixing an error on readme

<!-- Why are these changes necessary? -->

**Why**: In the complex example catch already sets error to ```error.message```. So in render, it should just show ```state.error```.

<!-- How were these changes implemented? -->

**How**: Render function updated to just show ```state.error``` instead of ```state.error.message```.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
Yes. Either that or catch shoud update error on the state as ```error: error``` instead of ```error: error.message```
<!-- feel free to add additional comments -->
