### PR TITLE
fix: make fireEvent mouseEnter/mouseLeave work with addEventListener

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -128,9 +128,6 @@ const eventTypes = [
   },
 ]
 
-// native select event isn't passing
-const nonNativeEvents = {doubleClick: 'dblclick', select: true}
-
 eventTypes.forEach(({type, events, elementType, init}) => {
   describe(`${type} Events`, () => {
     events.forEach(eventName => {
@@ -160,11 +157,10 @@ eventTypes.forEach(({type, events, elementType, init}) => {
   describe(`Native ${type} Events`, () => {
     events.forEach(eventName => {
       let nativeEventName = eventName.toLowerCase()
-      if (nonNativeEvents[eventName]) {
-        if (nonNativeEvents[eventName] === true) {
-          return
-        }
-        nativeEventName = nonNativeEvents[eventName]
+
+      // The doubleClick synthetic event maps to the dblclick native event
+      if (nativeEventName === 'doubleclick') {
+        nativeEventName = 'dblclick'
       }
 
       it(`triggers native ${nativeEventName}`, () => {

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -128,6 +128,9 @@ const eventTypes = [
   },
 ]
 
+// native select event isn't passing
+const nonNativeEvents = {doubleClick: 'dblclick', select: true}
+
 eventTypes.forEach(({type, events, elementType, init}) => {
   describe(`${type} Events`, () => {
     events.forEach(eventName => {
@@ -145,6 +148,42 @@ eventTypes.forEach(({type, events, elementType, init}) => {
             ref,
           }),
         )
+
+        fireEvent[eventName](ref.current, init)
+        expect(spy).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})
+
+eventTypes.forEach(({type, events, elementType, init}) => {
+  describe(`Native ${type} Events`, () => {
+    events.forEach(eventName => {
+      let nativeEventName = eventName.toLowerCase()
+      if (nonNativeEvents[eventName]) {
+        if (nonNativeEvents[eventName] === true) {
+          return
+        }
+        nativeEventName = nonNativeEvents[eventName]
+      }
+
+      it(`triggers native ${nativeEventName}`, () => {
+        const ref = React.createRef()
+        const spy = jest.fn()
+        const Element = elementType
+
+        const NativeEventElement = () => {
+          React.useEffect(() => {
+            const element = ref.current
+            element.addEventListener(nativeEventName, spy)
+            return () => {
+              element.removeEventListener(nativeEventName, spy)
+            }
+          })
+          return <Element ref={ref} />
+        }
+
+        render(<NativeEventElement />)
 
         fireEvent[eventName](ref.current, init)
         expect(spy).toHaveBeenCalledTimes(1)

--- a/src/pure.js
+++ b/src/pure.js
@@ -139,7 +139,9 @@ fireEvent.mouseLeave = (...args) => {
   return fireEvent.mouseOut(...args)
 }
 
+const select = fireEvent.select
 fireEvent.select = (node, init) => {
+  select(node, init)
   // React tracks this event only on focused inputs
   node.focus()
 

--- a/src/pure.js
+++ b/src/pure.js
@@ -128,8 +128,16 @@ Object.keys(dtlFireEvent).forEach(key => {
 // React event system tracks native mouseOver/mouseOut events for
 // running onMouseEnter/onMouseLeave handlers
 // @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/EnterLeaveEventPlugin.js#L24-L31
-fireEvent.mouseEnter = fireEvent.mouseOver
-fireEvent.mouseLeave = fireEvent.mouseOut
+const mouseEnter = fireEvent.mouseEnter
+const mouseLeave = fireEvent.mouseLeave
+fireEvent.mouseEnter = (...args) => {
+  mouseEnter(...args)
+  return fireEvent.mouseOver(...args)
+}
+fireEvent.mouseLeave = (...args) => {
+  mouseLeave(...args)
+  return fireEvent.mouseOut(...args)
+}
 
 fireEvent.select = (node, init) => {
   // React tracks this event only on focused inputs


### PR DESCRIPTION
(#577)

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Make `fireEvent.mouseEnter` and `fireEvent.mouseLeave` work with events added using `addEventListener`.

<!-- Why are these changes necessary? -->

**Why**:
There is no way to trigger a native mouseEnter/mouseLeave event using React Testing Library. A workaround is to manually use `dispatchEvent`, but it's not as convenient as `fireEvent`. The reason for this limitation is due to how React handles mouseEnter/mouseLeave: https://github.com/facebook/react/issues/12978

<!-- How were these changes implemented? -->

**How**:
Instead of setting `fireEvent.mouseEnter/Leave` to `fireEvent.mouseOver/Out`, set `fireEvent.mouseEnter/Leave` to call both `mouseEnter/Leave` and `fireEvent.mouseOver/Out`. 

This makes the behavior match other events that can be called with `fireEvent`. For example, if one click handler was added to an element with `addEventListener` and another was added to the component directly with `<button onClick={handleClick}>...`, `fireEvent.click(button)` calls both click handlers.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the N/A
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
Credit to @jessethomson