### PR TITLE
feat(debug): accept the same arguments as prettyDOM

### DIFF
--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -36,4 +36,17 @@ test('debug pretty prints multiple containers', () => {
   )
 })
 
+test('allows same arguments as prettyDOM', () => {
+  const HelloWorld = () => <h1>Hello World</h1>
+  const {debug, container} = render(<HelloWorld />)
+  debug(container, 6, {highlight: false})
+  expect(console.log).toHaveBeenCalledTimes(1)
+  expect(console.log.mock.calls[0]).toMatchInlineSnapshot(`
+    Array [
+      "<div>
+    ...",
+    ]
+  `)
+})
+
 /* eslint no-console:0 */

--- a/src/pure.js
+++ b/src/pure.js
@@ -60,12 +60,12 @@ function render(
   return {
     container,
     baseElement,
-    debug: (el = baseElement) =>
+    debug: (el = baseElement, maxLength, options) =>
       Array.isArray(el)
         ? // eslint-disable-next-line no-console
-          el.forEach(e => console.log(prettyDOM(e)))
+          el.forEach(e => console.log(prettyDOM(e, maxLength, options)))
         : // eslint-disable-next-line no-console,
-          console.log(prettyDOM(el)),
+          console.log(prettyDOM(el, maxLength, options)),
     unmount: () => ReactDOM.unmountComponentAtNode(container),
     rerender: rerenderUi => {
       render(wrapUiIfNeeded(rerenderUi), {container, baseElement})


### PR DESCRIPTION
**What**: make debug accept the same args as prettyDOM

**Why**: Closes #580 

**How**: Accepting additional args and forwarding them along.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the docs site (accidentally committed it directly to master 🙈 https://github.com/testing-library/testing-library-docs/commit/f6b73763b99dd743eac1a4492a14cf9db6463ccd)
- [x] Tests
- [ ] Typescript definitions updated (got this started, but I don't have the bandwidth to finish: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42837)
- [x] Ready to be merged