### PR TITLE
Remove cleanup-after-each

### DIFF
--- a/cleanup-after-each.js
+++ b/cleanup-after-each.js
@@ -1,4 +1,0 @@
-console.warn(
-  'The module `@testing-library/react/cleanup-after-each` has been deprecated and no longer does anything (it is not needed). You no longer need to import this module and can safely remove any import or configuration which imports this module',
-)
-/* eslint no-console:0 */

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "files": [
     "dist",
-    "cleanup-after-each.js",
     "dont-cleanup-after-each.js",
     "pure.js"
   ],


### PR DESCRIPTION
It was deprecated in the last release, so we could safely delete it now I think 🙂