### PR TITLE
fix: Bump types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@babel/runtime": "^7.9.2",
     "@testing-library/dom": "^7.1.0",
-    "@types/testing-library__react": "^9.1.3"
+    "@types/testing-library__react": "^10.0.0"
   },
   "devDependencies": {
     "@reach/router": "^1.3.3",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Bump @types/testing-library__react to ^10.0.0

<!-- Why are these changes necessary? -->

**Why**:

I can't use new stuff from v10 because types are outdated

<!-- How were these changes implemented? -->

**How**:

Increased number in package.json

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Tests N/A
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
