### PR TITLE
fix(cleanup): Cleanup should flush microtask queue after unmounting containers

### DIFF
--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -26,3 +26,17 @@ test('cleanup does not error when an element is not a child', async () => {
   render(<div />, {container: document.createElement('div')})
   await cleanup()
 })
+
+test('cleanup waits for queued microtasks during unmount sequence', async () => {
+  const spy = jest.fn()
+
+  const Test = () => {
+    React.useEffect(() => () => setImmediate(spy))
+
+    return null
+  }
+
+  render(<Test />)
+  await cleanup()
+  expect(spy).toHaveBeenCalledTimes(1)
+})

--- a/src/pure.js
+++ b/src/pure.js
@@ -90,8 +90,8 @@ function render(
 }
 
 async function cleanup() {
-  await flush()
   mountedContainers.forEach(cleanupAtContainer)
+  await flush()
 }
 
 // maybe one day we'll expose this (perhaps even as a utility returned by render).

--- a/src/pure.js
+++ b/src/pure.js
@@ -91,6 +91,8 @@ function render(
 
 async function cleanup() {
   mountedContainers.forEach(cleanupAtContainer)
+  // flush microtask queue after unmounting in case
+  // unmount sequence generates new microtasks
   await flush()
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

The `cleanup` routine should unmount mounted containers first to trigger all the effect cleanup routines and _then_ flush the microtask queue.

**Why**:

<!-- How were these changes implemented? -->

When using some libraries such as `react-query` or `react-modal`, there can be unmounting routines that schedule immediate microtasks to perform cleanup.

I've documented a specific case [here in react-query](https://github.com/tannerlinsley/react-query/issues/270#issuecomment-610560262) where I was seeing testing inconsistencies unless I explicitly called `unmount` during the test.

In React Modal specifically, here's a snippet from one of their `componentWillUnmount` cleanup routines:

https://github.com/reactjs/react-modal/blob/v3.11.2/src/components/Modal.js#L153-L172

**How**:

<!-- Have you done all of these things?  -->

I moved the `await flush()` to be after unmounting containers. I've added a test case that fails when using `setImmediate` during an effect cleanup routine.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)  N/A
- [x] Tests
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I think this is a safe (and correct) change but it is a change in behavior that could have side effects.