### PR TITLE
fix: restore this when requiring timers

### DIFF
--- a/src/flush-microtasks.js
+++ b/src/flush-microtasks.js
@@ -15,7 +15,7 @@ try {
   const nodeRequire = module && module[requireString]
   // assuming we're in node, let's try to get node's
   // version of setImmediate, bypassing fake timers if any.
-  enqueueTask = nodeRequire('timers').setImmediate
+  enqueueTask = nodeRequire.call(module, 'timers').setImmediate
 } catch (_err) {
   // we're in a browser
   // we can't use regular timers because they may still be faked


### PR DESCRIPTION


**What**:

closes #614

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A
- [ ] Tests (not testable in the current setup)
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged 
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
