### PR TITLE
Return value from debug for test runners like Wallaby.js

### DIFF
--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -23,13 +23,13 @@ test('debug returns the container', () => {
   const HelloWorld = () => <h1>Hello World</h1>
   const {debug} = render(<HelloWorld />)
   expect(debug()).toMatchInlineSnapshot(`
-    "[36m<body>[39m
-      [36m<div>[39m
-        [36m<h1>[39m
-          [0mHello World[0m
-        [36m</h1>[39m
-      [36m</div>[39m
-    [36m</body>[39m"
+    "<body>
+      <div>
+        <h1>
+          Hello World
+        </h1>
+      </div>
+    </body>"
   `)
 })
 
@@ -62,16 +62,16 @@ test('debug returns multiple containers', () => {
 
   expect(debug(multipleElements)).toMatchInlineSnapshot(`
     Array [
-      "[36m<h1[39m
-      [33mdata-testid[39m=[32m\\"testId\\"[39m
-    [36m>[39m
-      [0mHello World[0m
-    [36m</h1>[39m",
-      "[36m<h1[39m
-      [33mdata-testid[39m=[32m\\"testId\\"[39m
-    [36m>[39m
-      [0mHello World[0m
-    [36m</h1>[39m",
+      "<h1
+      data-testid=\\"testId\\"
+    >
+      Hello World
+    </h1>",
+      "<h1
+      data-testid=\\"testId\\"
+    >
+      Hello World
+    </h1>",
     ]
   `)
 })

--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -19,6 +19,20 @@ test('debug pretty prints the container', () => {
   )
 })
 
+test('debug returns the container', () => {
+  const HelloWorld = () => <h1>Hello World</h1>
+  const {debug} = render(<HelloWorld />)
+  expect(debug()).toMatchInlineSnapshot(`
+    "[36m<body>[39m
+      [36m<div>[39m
+        [36m<h1>[39m
+          [0mHello World[0m
+        [36m</h1>[39m
+      [36m</div>[39m
+    [36m</body>[39m"
+  `)
+})
+
 test('debug pretty prints multiple containers', () => {
   const HelloWorld = () => (
     <>
@@ -34,6 +48,32 @@ test('debug pretty prints multiple containers', () => {
   expect(console.log).toHaveBeenCalledWith(
     expect.stringContaining('Hello World'),
   )
+})
+
+test('debug returns multiple containers', () => {
+  const HelloWorld = () => (
+    <>
+      <h1 data-testid="testId">Hello World</h1>
+      <h1 data-testid="testId">Hello World</h1>
+    </>
+  )
+  const {debug} = render(<HelloWorld />)
+  const multipleElements = screen.getAllByTestId('testId')
+
+  expect(debug(multipleElements)).toMatchInlineSnapshot(`
+    Array [
+      "[36m<h1[39m
+      [33mdata-testid[39m=[32m\\"testId\\"[39m
+    [36m>[39m
+      [0mHello World[0m
+    [36m</h1>[39m",
+      "[36m<h1[39m
+      [33mdata-testid[39m=[32m\\"testId\\"[39m
+    [36m>[39m
+      [0mHello World[0m
+    [36m</h1>[39m",
+    ]
+  `)
 })
 
 test('allows same arguments as prettyDOM', () => {

--- a/src/pure.js
+++ b/src/pure.js
@@ -61,12 +61,21 @@ function render(
   return {
     container,
     baseElement,
-    debug: (el = baseElement, maxLength, options) =>
-      Array.isArray(el)
-        ? // eslint-disable-next-line no-console
-          el.forEach(e => console.log(prettyDOM(e, maxLength, options)))
-        : // eslint-disable-next-line no-console,
-          console.log(prettyDOM(el, maxLength, options)),
+    debug: (el = baseElement, maxLength, options) => {
+      if (Array.isArray(el)) {
+        return el.map(e => {
+          const items = prettyDOM(e, maxLength, options)
+          // eslint-disable-next-line no-console
+          console.log(items)
+          return items
+        })
+      }
+
+      const item = prettyDOM(el, maxLength, options)
+      // eslint-disable-next-line no-console
+      console.log(item)
+      return item
+    },
     unmount: () => ReactDOM.unmountComponentAtNode(container),
     rerender: rerenderUi => {
       render(wrapUiIfNeeded(rerenderUi), {container, baseElement})

--- a/src/pure.js
+++ b/src/pure.js
@@ -64,17 +64,15 @@ function render(
     debug: (el = baseElement, maxLength, options) => {
       if (Array.isArray(el)) {
         return el.map(e => {
-          const items = prettyDOM(e, maxLength, options)
           // eslint-disable-next-line no-console
-          console.log(items)
-          return items
+          console.log(prettyDOM(e, maxLength, options))
+          return prettyDOM(e, maxLength, { ...options, highlight: false })
         })
       }
 
-      const item = prettyDOM(el, maxLength, options)
       // eslint-disable-next-line no-console
-      console.log(item)
-      return item
+      console.log(prettyDOM(el, maxLength, options))
+      return prettyDOM(el, maxLength, { ...options, highlight: false })
     },
     unmount: () => ReactDOM.unmountComponentAtNode(container),
     rerender: rerenderUi => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

When using [Wallaby.js](https://wallabyjs.com) there is currently no way to get the output of the `debug` function in the interface. This is because the `debug` function just logs the changes and doesn't return anything. This PR will return a `string` or an `array` of `string`s from the `debug` function, which will enable:

![image](https://user-images.githubusercontent.com/862834/80929383-ee6bda80-8dee-11ea-904f-4d78c7a33369.jpeg)

**Why**:

The `debug` function has been updated to `console.log` the output first — maintaining the current functionality. And then return a `string` or an `array` of `string`s using `prettyDom` without the `highlight` option.

**How**:
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs) N/A (I don't think this needs an update)
- [x] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I have pulled down the `DefinitelyTyped` repo and made the changes there — [pr/branch](https://github.com/deshiknaves/DefinitelyTyped/tree/pr/testing-library-react-debug-return-type). I'm a little bit unsure of which order the PRs should go in. I'm thinking this should be merged first and then the update to `DefinitelyTyped`? Let me know if I'm wrong and I can do whatever is required.