### PR TITLE
Run cleanup() when test runner supports teardown()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import {cleanup} from './pure'
 // if you don't like this then either import the `pure` module
 // or set the RTL_SKIP_AUTO_CLEANUP env variable to 'true'.
 if (!process.env.RTL_SKIP_AUTO_CLEANUP) {
+  // ignore teardown() in code coverage because Jest does not support it
+  /* istanbul ignore else */
   if (typeof afterEach === 'function') {
     afterEach(async () => {
       await cleanup()

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,9 @@ if (!process.env.RTL_SKIP_AUTO_CLEANUP) {
       await cleanup()
     })
   } else if (typeof teardown === 'function') {
+    // Block is guarded by `typeof` check.
+    // eslint does not support `typeof` guards.
+    // eslint-disable-next-line no-undef
     teardown(async () => {
       await cleanup()
     })

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,20 @@
 import {cleanup} from './pure'
 
 // if we're running in a test runner that supports afterEach
-// then we'll automatically run cleanup afterEach test
+// or teardown then we'll automatically run cleanup afterEach test
 // this ensures that tests run in isolation from each other
 // if you don't like this then either import the `pure` module
 // or set the RTL_SKIP_AUTO_CLEANUP env variable to 'true'.
-if (typeof afterEach === 'function' && !process.env.RTL_SKIP_AUTO_CLEANUP) {
-  afterEach(async () => {
-    await cleanup()
-  })
+if (!process.env.RTL_SKIP_AUTO_CLEANUP) {
+  if (typeof afterEach === 'function') {
+    afterEach(async () => {
+      await cleanup()
+    })
+  } else if (typeof teardown === 'function') {
+    teardown(async () => {
+      await cleanup()
+    })
+  }
 }
 
 export * from './pure'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

`cleanup()` now runs not only when `afterEach()` exists. It also runs when `teardown()` exists.

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

There are test runners that either don't have a `afterEach()` function or supports different UI's, like [Mocha's TDD UI](https://mochajs.org/#tdd) for example. It would be great if `react-testing-library` would also support `teardown()` for cleaning up things.

**How**:

I just added an additional check that checks and calls `teardown()` instead of `beforeEach()`.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/alexkrolick/testing-library-docs)
- [ ] Tests
- [ ] Typescript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

The main problem that I have with this pull request is:

- linting fails because `teardown` is not defined. Is this somewhere deep in `eslint-config-kentcdodds`?
- I had problems to write a test for that because you are using `Jest` which does not have `teardown()`
