### PR TITLE
fix(fireEvent): automatically configure `fireEvent` to be wrapped in act

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ cache: npm
 notifications:
   email: false
 node_js:
-  - 10.0.0
+  # technically we support 10.0.0, but some of our tooling doesn't
+  - 10.14.2
   - 12
   - 14
   - node

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -1,0 +1,44 @@
+import {fireEvent as dtlFireEvent} from '@testing-library/dom'
+
+// react-testing-library's version of fireEvent will call
+// dom-testing-library's version of fireEvent. The reason
+// we make this distinction however is because we have
+// a few extra events that work a bit differently
+const fireEvent = (...args) => dtlFireEvent(...args)
+
+Object.keys(dtlFireEvent).forEach(key => {
+  fireEvent[key] = (...args) => dtlFireEvent[key](...args)
+})
+
+// React event system tracks native mouseOver/mouseOut events for
+// running onMouseEnter/onMouseLeave handlers
+// @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/EnterLeaveEventPlugin.js#L24-L31
+const mouseEnter = fireEvent.mouseEnter
+const mouseLeave = fireEvent.mouseLeave
+fireEvent.mouseEnter = (...args) => {
+  mouseEnter(...args)
+  return fireEvent.mouseOver(...args)
+}
+fireEvent.mouseLeave = (...args) => {
+  mouseLeave(...args)
+  return fireEvent.mouseOut(...args)
+}
+
+const select = fireEvent.select
+fireEvent.select = (node, init) => {
+  select(node, init)
+  // React tracks this event only on focused inputs
+  node.focus()
+
+  // React creates this event when one of the following native events happens
+  // - contextMenu
+  // - mouseUp
+  // - dragEnd
+  // - keyUp
+  // - keyDown
+  // so we can use any here
+  // @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/SelectEventPlugin.js#L203-L224
+  fireEvent.keyUp(node, init)
+}
+
+export {fireEvent}


### PR DESCRIPTION
**What**: fix(fireEvent): automatically configure `fireEvent` to be wrapped in act 

<!-- Why are these changes necessary? -->

**Why**: Because now we don't have to do this nonsense: https://github.com/testing-library/react-testing-library/blob/0afcbea3c3d1ddce218a36d963d39fa83f9a7cf6/src/pure.js#L107-L128

It also means that `fireEvent` will be globally configured to be wrapped in `act` so even if people import the DOM Testing Library one (like we do in `@testing-libary/user-event`), it will be wrapped in act (assuming they've also imported `@testing-library/react`).

One note is that `pure.js` is not actually pure and never was because it configures DOM Testing Library globally. Perhaps in the future we should make a breaking change to make `pure.js` actually pure.

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the N/A
- [ ] Tests N/A (though I did verify that the one test we had to ensure `act` was called correctly is still passing)
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged

Now not only will React Testing Library's `fireEvent` be wrapped in
`act`, but so will DOM Testing Library's `fireEvent` (if
`@testing-library/react` is imported). It works very similar to async
act for the `asyncWrapper` config.

Closes: https://github.com/testing-library/user-event/issues/188
Closes: https://github.com/testing-library/user-event/issues/255
Reference: https://github.com/testing-library/user-event/issues/277
