### PR TITLE
Added the ability to pass props to the wrapper component in render()

### DIFF
--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -87,3 +87,30 @@ test('renders options.wrapper around node', () => {
 </div>
 `)
 })
+
+test('passes options.wrapperProps to wrapper', () => {
+  const WrapperComponent = ({divClass, children}) => (
+    <div className={divClass} data-testid="wrapper-with-prop">
+      {children}
+    </div>
+  )
+
+  const {container} = render(<div data-testid="inner" />, {
+    wrapper: WrapperComponent,
+    wrapperProps: {
+      divClass: 'passed-by-prop',
+    },
+  })
+
+  expect(screen.getByTestId('wrapper-with-prop')).toBeInTheDocument()
+  expect(container.firstChild).toMatchInlineSnapshot(`
+<div
+  class="passed-by-prop"
+  data-testid="wrapper-with-prop"
+>
+  <div
+    data-testid="inner"
+  />
+</div>
+`)
+})

--- a/src/pure.js
+++ b/src/pure.js
@@ -36,6 +36,7 @@ function render(
     queries,
     hydrate = false,
     wrapper: WrapperComponent,
+    wrapperProps = null,
   } = {},
 ) {
   if (!baseElement) {
@@ -54,7 +55,7 @@ function render(
 
   const wrapUiIfNeeded = innerElement =>
     WrapperComponent
-      ? React.createElement(WrapperComponent, null, innerElement)
+      ? React.createElement(WrapperComponent, wrapperProps, innerElement)
       : innerElement
 
   act(() => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,6 +28,7 @@ export interface RenderOptions<Q extends Queries = typeof queries> {
   hydrate?: boolean
   queries?: Q
   wrapper?: React.ComponentType
+  wrapperProps?: object | null
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I have added an additional option to `render` called `wrapperProps` to allow props to be passed to the wrapper component on creation. By default this is `null` (as before), meaning no breaking changes.

**Why**:

I found the need to pass additional props to my custom provider wrapper as outlined in the docs. Specifically I am using the Apollo Client provider `MockedProvider`, which allows mock responses to be applied using the provider.

**How**:

Simply replaced `React.createElement(..., PROPS, ...)` with an option variable passed into render, rather than always being `null`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Will update the docs if this request is approved.
