### PR TITLE
Add iFood to users

### DIFF
--- a/other/USERS.md
+++ b/other/USERS.md
@@ -3,10 +3,10 @@
 If you or your company uses this project, add your name to this list! Eventually
 we may have a website to showcase these (wanna build it!?)
 
-> No users have been added yet!
-
 <!--
 This file should just be a bulleted list like this:
 
 - [Company/Project/Person](https://example.com) uses it in [some app](https://example.com)
 -->
+
+- Used by [iFood](https://www.ifood.com.br/)'s frontend team


### PR DESCRIPTION
Responding to this request we got in Reactiflux:

> Hi, there! I work at iFood, the largest foodtech delivery in Latin America. I want to understand how do you select the companies that appear in the section Who's Using This in the Testing Library because we would like to join that - our frontend team is a heavy user of your platform! Tks a lot, Larissa

__Note:__ The site appears to only be available in Brazilian Portuguese

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

