### PR TITLE
fix(flushMicroTasks): Fallback to no scheduler in case of exception

### DIFF
--- a/src/flush-microtasks.js
+++ b/src/flush-microtasks.js
@@ -20,9 +20,6 @@ function getIsUsingFakeTimers() {
 
 const globalObj = typeof window === 'undefined' ? global : window
 let Scheduler = globalObj.Scheduler
-let isModernScheduleCallbackSupported = satisfies(React.version, '>16.8.6', {
-  includePrerelease: true,
-})
 
 let didWarnAboutMessageChannel = false
 let enqueueTask

--- a/src/flush-microtasks.js
+++ b/src/flush-microtasks.js
@@ -20,7 +20,7 @@ function getIsUsingFakeTimers() {
 
 const globalObj = typeof window === 'undefined' ? global : window
 let Scheduler = globalObj.Scheduler
-const isModernScheduleCallbackSupported = satisfies(React.version, '>16.8.6', {
+let isModernScheduleCallbackSupported = satisfies(React.version, '>16.8.6', {
   includePrerelease: true,
 })
 
@@ -57,6 +57,17 @@ try {
           'Please file an issue at https://github.com/facebook/react/issues ' +
           'if you encounter this warning.',
       )
+    }
+
+    if (isModernScheduleCallbackSupported) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'This environment does not support module requiring, so we cannot require the Scheduler. ' +
+          'To fix this you can require the Scheduler in your test setup file.',
+      )
+
+      // Fallback to no scheduleCallback Supported.
+      isModernScheduleCallbackSupported = false
     }
   }
 }

--- a/src/flush-microtasks.js
+++ b/src/flush-microtasks.js
@@ -59,18 +59,12 @@ try {
       )
     }
 
-    if (isModernScheduleCallbackSupported) {
-      // eslint-disable-next-line no-console
-      console.error(
-        'This environment does not support module requiring, so we cannot require the Scheduler. ' +
-          'To fix this you can require the Scheduler in your test setup file.',
-      )
-
-      // Fallback to no scheduleCallback Supported.
-      isModernScheduleCallbackSupported = false
-    }
   }
 }
+
+const isModernScheduleCallbackSupported = Scheduler && satisfies(React.version, '>16.8.6', {
+  includePrerelease: true,
+})
 
 function scheduleCallback(cb) {
   const NormalPriority = Scheduler


### PR DESCRIPTION
Closes #736 

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: When we couldn't require the `scheduler` package we will now fallback to `isModernScheduleCallbackSupported = false` meaning we will use `callback => callback()`. 

<!-- Why are these changes necessary? -->

**Why**: Following the conversation in #736 - We found this to be a proper solution for now in case the `Scheduler` wasn't loaded.
I still think we need to discuss this issue further and think if we can be able to figure a different way to require the `Scheduler` at runtime.

<!-- How were these changes implemented? -->

**How**: I've added an if statement in the catch block to see if `isModernScheduleCallbackSupported` is `true`, in that case I change it to `false` and write an error to console.

I think that we may need to separate the try catch to two different ones and handle each error for it's own. Update me what you think please :)
Also, within the error message we may want to link to the documentation stating how to fix this one.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) - We need to implement a documentation change for this one, please update me where you think it fits.
- [ ] Tests - N/A
- [ ] Typescript definitions updated - N/A
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
