### PR TITLE
chore(flushMicroTasks): Use the mocked scheduler when available

### DIFF
--- a/src/flush-microtasks.js
+++ b/src/flush-microtasks.js
@@ -55,13 +55,14 @@ try {
           'if you encounter this warning.',
       )
     }
-
   }
 }
 
-const isModernScheduleCallbackSupported = Scheduler && satisfies(React.version, '>16.8.6', {
-  includePrerelease: true,
-})
+const isModernScheduleCallbackSupported =
+  Scheduler &&
+  satisfies(React.version, '>16.8.6', {
+    includePrerelease: true,
+  })
 
 function scheduleCallback(cb) {
   const NormalPriority = Scheduler
@@ -86,6 +87,9 @@ export default function flushMicroTasks() {
         // reproduce the problem, so there's no test for it. But it works!
         jest.advanceTimersByTime(0)
         resolve()
+      } else if (Scheduler && Scheduler.unstable_flushAll) {
+        Scheduler.unstable_flushAll()
+        enqueueTask(resolve)
       } else {
         scheduleCallback(() => enqueueTask(resolve))
       }

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom/extend-expect'
+jest.mock('scheduler', () => jest.requireActual('scheduler/unstable_mock'))


### PR DESCRIPTION
Following a conversation with @eps1lon, he pointed out that maybe it would be better to mock the Scheduler (based on [this](https://github.com/facebook/react/pull/14964) PR by @acdlite).

This solution will handle both mocked version of scheduler and original version.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: I've mocked the scheduler package in our setup-env and used the `flushAll` function which is available in the mocked scheduler package.

<!-- Why are these changes necessary? -->

**Why**: React core team recommends to use a mocked version of the scheduler in test environments. We need to think if we want to recommend our users to mock the scheduler package also in their test environments. I think that if our users will mock the scheduler package, we won't need to know if someone is using fake timers or not and just call `flushAll`.

<!-- How were these changes implemented? -->

**How**: Checked for the presence of `unstable_flushAll` and used it if it exists. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) - N/A
- [ ] Tests - N/A
- [ ] Typescript definitions updated - N/A
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I'm opening this one to create the conversation here and see what you think about it.