### PR TITLE
fix(cleanup): remove scheduler code from flush-microtasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.10.3",
-    "@testing-library/dom": "^7.17.1",
-    "semver": "^7.3.2"
+    "@testing-library/dom": "^7.17.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.10.1",

--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -31,7 +31,7 @@ test('cleanup waits for queued microtasks during unmount sequence', async () => 
   const spy = jest.fn()
 
   const Test = () => {
-    React.useEffect(() => () => setImmediate(spy))
+    React.useEffect(() => () => setTimeout(spy, 200))
 
     return null
   }

--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -27,11 +27,11 @@ test('cleanup does not error when an element is not a child', async () => {
   await cleanup()
 })
 
-test('cleanup waits for queued microtasks during unmount sequence', async () => {
+test('cleanup runs effect cleanup functions', async () => {
   const spy = jest.fn()
 
   const Test = () => {
-    React.useEffect(() => () => setTimeout(spy, 200))
+    React.useEffect(() => spy)
 
     return null
   }

--- a/src/flush-microtasks.js
+++ b/src/flush-microtasks.js
@@ -1,6 +1,3 @@
-import React from 'react'
-import satisfies from 'semver/functions/satisfies'
-
 /* istanbul ignore file */
 // the part of this file that we need tested is definitely being run
 // and the part that is not cannot easily have useful tests written
@@ -18,9 +15,6 @@ function getIsUsingFakeTimers() {
   )
 }
 
-const globalObj = typeof window === 'undefined' ? global : window
-let Scheduler = globalObj.Scheduler
-
 let didWarnAboutMessageChannel = false
 let enqueueTask
 
@@ -32,8 +26,6 @@ try {
   // assuming we're in node, let's try to get node's
   // version of setImmediate, bypassing fake timers if any.
   enqueueTask = nodeRequire.call(module, 'timers').setImmediate
-  // import React's scheduler so we'll be able to schedule our tasks later on.
-  Scheduler = nodeRequire.call(module, 'scheduler')
 } catch (_err) {
   // we're in a browser
   // we can't use regular timers because they may still be faked
@@ -55,26 +47,7 @@ try {
           'if you encounter this warning.',
       )
     }
-
   }
-}
-
-const isModernScheduleCallbackSupported = Scheduler && satisfies(React.version, '>16.8.6', {
-  includePrerelease: true,
-})
-
-function scheduleCallback(cb) {
-  const NormalPriority = Scheduler
-    ? Scheduler.NormalPriority || Scheduler.unstable_NormalPriority
-    : null
-
-  const scheduleFn = Scheduler
-    ? Scheduler.scheduleCallback || Scheduler.unstable_scheduleCallback
-    : callback => callback()
-
-  return isModernScheduleCallbackSupported
-    ? scheduleFn(NormalPriority, cb)
-    : scheduleFn(cb)
 }
 
 export default function flushMicroTasks() {
@@ -87,7 +60,7 @@ export default function flushMicroTasks() {
         jest.advanceTimersByTime(0)
         resolve()
       } else {
-        scheduleCallback(() => enqueueTask(resolve))
+        enqueueTask(resolve)
       }
     },
   }


### PR DESCRIPTION
**What**: This removes the scheduler code from flush-microtasks

**Why**: Because the test that failed is fundamentally flawed

<!-- How were these changes implemented? -->

**How**:

1. Rewrite the test to illustrate why it's flawed (we can't and shouldn't guarantee that all scheduled tasks will run simply as a result of cleanup)
2. Rewrite the test to not test for that
3. Fix the implementation of flush-microtasks to not use the scheduler (basically revert everything we did for #726 and change the test instead).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

~- [ ] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs)~ N/A
- [ ] Tests
~- [ ] Typescript definitions updated~ N/A
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Closes #743 