### PR TITLE
fix(unmount): Flush useEffect cleanup functions syncronously

### DIFF
--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -87,3 +87,17 @@ test('renders options.wrapper around node', () => {
 </div>
 `)
 })
+
+test('flushes useEffect cleanup functions sync on unmount()', () => {
+  const spy = jest.fn()
+  function Component() {
+    React.useEffect(() => spy, [])
+    return null
+  }
+  const {unmount} = render(<Component />)
+  expect(spy).toHaveBeenCalledTimes(0)
+
+  unmount()
+
+  expect(spy).toHaveBeenCalledTimes(1)
+})

--- a/src/pure.js
+++ b/src/pure.js
@@ -74,7 +74,11 @@ function render(
           el.forEach(e => console.log(prettyDOM(e, maxLength, options)))
         : // eslint-disable-next-line no-console,
           console.log(prettyDOM(el, maxLength, options)),
-    unmount: () => ReactDOM.unmountComponentAtNode(container),
+    unmount: () => {
+      act(() => {
+        ReactDOM.unmountComponentAtNode(container)
+      })
+    },
     rerender: rerenderUi => {
       render(wrapUiIfNeeded(rerenderUi), {container, baseElement})
       // Intentionally do not return anything to avoid unnecessarily complicating the API.


### PR DESCRIPTION
**What**:

Flush cleanup functions from `useEffect` synchronously on `unmount`.

**Why**:

`react@next` no longer flushes cleanup functions from `useEffect` synchronously.
Verified in https://travis-ci.org/github/testing-library/react-testing-library/builds/708314737

**How**:

Wrap `unmountComponentAtNode` in `act`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I'm not touching `cleanup` and `flush-microtasks` for now. We can do that in a follow-up PR that we test extensively against existing repos.
