### PR TITLE
test(fireEvent): Add expected behavior for blur/focus in React

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -211,3 +211,30 @@ test('calling `fireEvent` directly works too', () => {
     }),
   )
 })
+
+test('blur/foucs bubbles in react', () => {
+  const handleBlur = jest.fn()
+  const handleBubbledBlur = jest.fn()
+  const handleFocus = jest.fn()
+  const handleBubbledFocus = jest.fn()
+  const {container} = render(
+    <div onBlur={handleBubbledBlur} onFocus={handleBubbledFocus}>
+      <button onBlur={handleBlur} onFocus={handleFocus} />
+    </div>,
+  )
+  const button = container.firstChild.firstChild
+
+  fireEvent.focus(button)
+
+  expect(handleBlur).toHaveBeenCalledTimes(0)
+  expect(handleBubbledBlur).toHaveBeenCalledTimes(0)
+  expect(handleFocus).toHaveBeenCalledTimes(1)
+  expect(handleBubbledFocus).toHaveBeenCalledTimes(1)
+
+  fireEvent.blur(button)
+
+  expect(handleBlur).toHaveBeenCalledTimes(1)
+  expect(handleBubbledBlur).toHaveBeenCalledTimes(1)
+  expect(handleFocus).toHaveBeenCalledTimes(1)
+  expect(handleBubbledFocus).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Add expected behavior for blur and focus bubbling in React. This is different than native DOM events where blur and focus do not bubble

**Why**:

Got messaged by core members that they **might** start listening to `focusin`/`focusout` instead which would cause our current `fireEvent.focus` implementation to not register React focus events. We should also fire `focusin`/`focusout` once they start doing that (i.e. `react@next` starts breaking the build) which is similar to [how we handle `mouseEnter`/`mouseLeave`](https://github.com/testing-library/react-testing-library/blob/6147830b0ea61341d02f520d2a26b817996e3a4a/src/fire-event.js#L13-L25).

Ideally we'd get everybody on board to using `.focus()` and `blur()` instead but that would only work with `jsdom@16.3.0` or a browser which is less than ideal.

**How**:

Assert on invocation of event handlers for bubbled events

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~
- [x] Tests
- ~[ ] Typescript definitions updated~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
