### PR TITLE
fix(cleanup): remove unnecessary async/await

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,15 +9,15 @@ if (!process.env.RTL_SKIP_AUTO_CLEANUP) {
   // ignore teardown() in code coverage because Jest does not support it
   /* istanbul ignore else */
   if (typeof afterEach === 'function') {
-    afterEach(async () => {
-      await cleanup()
+    afterEach(() => {
+      cleanup()
     })
   } else if (typeof teardown === 'function') {
     // Block is guarded by `typeof` check.
     // eslint does not support `typeof` guards.
     // eslint-disable-next-line no-undef
-    teardown(async () => {
-      await cleanup()
+    teardown(() => {
+      cleanup()
     })
   }
 }


### PR DESCRIPTION
**What**:
removed async/await on cleanup afterEach

**Why**:

no longer needed due to 11.0

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] Typescript definitions updated
- [x] Ready to be merged

