### PR TITLE
fix: Trigger onPointerEnter/Leave when calling pointerEnter/Leave

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -199,16 +199,22 @@ test('onChange works', () => {
 
 test('calling `onPointerEnter` directly works too', () => {
   const handlePointerEnter = jest.fn()
+  const handlePointerLeave = jest.fn()
   const {container} = render(
     <div>
-      <button onPointerEnter={handlePointerEnter} />
+      <button
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+      />
     </div>,
   )
   const button = container.firstChild.firstChild
 
   fireEvent.pointerEnter(button)
-
   expect(handlePointerEnter).toHaveBeenCalledTimes(1)
+
+  fireEvent.pointerLeave(button)
+  expect(handlePointerLeave).toHaveBeenCalledTimes(1)
 })
 
 test('calling `fireEvent` directly works too', () => {

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -198,17 +198,17 @@ test('onChange works', () => {
 })
 
 test('calling `onPointerEnter` directly works too', () => {
-  const handleBlur = jest.fn()
+  const handlePointerEnter = jest.fn()
   const {container} = render(
     <div>
-      <button onPointerEnter={handleBlur} />
+      <button onPointerEnter={handlePointerEnter} />
     </div>,
   )
   const button = container.firstChild.firstChild
 
   fireEvent.pointerEnter(button)
 
-  expect(handleBlur).toHaveBeenCalledTimes(1)
+  expect(handlePointerEnter).toHaveBeenCalledTimes(1)
 })
 
 test('calling `fireEvent` directly works too', () => {

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -216,7 +216,7 @@ test('calling `fireEvent` directly works too', () => {
   const {
     container: {firstChild: button},
   } = render(<button onClick={handleEvent} />)
-  fireEvent.pointerEnter(
+  fireEvent(
     button,
     new Event('MouseEvent', {
       bubbles: true,

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -197,12 +197,26 @@ test('onChange works', () => {
   expect(handleChange).toHaveBeenCalledTimes(1)
 })
 
+test('calling `onPointerEnter` directly works too', () => {
+  const handleBlur = jest.fn()
+  const {container} = render(
+    <div>
+      <button onPointerEnter={handleBlur} />
+    </div>,
+  )
+  const button = container.firstChild.firstChild
+
+  fireEvent.pointerEnter(button)
+
+  expect(handleBlur).toHaveBeenCalledTimes(1)
+})
+
 test('calling `fireEvent` directly works too', () => {
   const handleEvent = jest.fn()
   const {
     container: {firstChild: button},
   } = render(<button onClick={handleEvent} />)
-  fireEvent(
+  fireEvent.pointerEnter(
     button,
     new Event('MouseEvent', {
       bubbles: true,

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -24,6 +24,17 @@ fireEvent.mouseLeave = (...args) => {
   return fireEvent.mouseOut(...args)
 }
 
+const pointerEnter = fireEvent.pointerEnter
+const pointerLeave = fireEvent.pointerLeave
+fireEvent.pointerEnter = (...args) => {
+  pointerEnter(...args)
+  return fireEvent.pointerOver(...args)
+}
+fireEvent.pointerLeave = (...args) => {
+  pointerLeave(...args)
+  return fireEvent.pointerOut(...args)
+}
+
 const select = fireEvent.select
 fireEvent.select = (node, init) => {
   select(node, init)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Pointer events added**:

<!-- Why are these changes necessary? -->

**Existing code doesn't include pointer events**:

<!-- How were these changes implemented? -->

**Similar to the mouse events**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the N/A
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [ ] Typescript definitions updated  N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
