### PR TITLE
fix: Trigger ongot-/onlostpointercapture when calling got-/lostpointercapture

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@testing-library/dom": "^7.23.0"
+    "@testing-library/dom": "^7.24.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -63,6 +63,26 @@ const eventTypes = [
     elementType: 'button',
   },
   {
+    // PointerEvent isn't supported in JSDOM.
+    // We're using MouseEvent since PointerEvent extends it.
+    // type: 'Pointer',
+    type: 'Mouse',
+    events: [
+      'pointerOver',
+      'pointerEnter',
+      'pointerDown',
+      'pointerMove',
+      'pointerUp',
+      'pointerCancel',
+      'pointerOut',
+      'pointerLeave',
+      // FIXME: Issue in dtl? Manual dispatch works in test "gotPointerCapture"
+      // 'gotPointerCapture',
+      // 'lostPointerCapture',
+    ],
+    elementType: 'button',
+  },
+  {
     type: 'Selection',
     events: ['select'],
     elementType: 'input',
@@ -197,26 +217,6 @@ test('onChange works', () => {
   expect(handleChange).toHaveBeenCalledTimes(1)
 })
 
-test('calling `onPointerEnter` directly works too', () => {
-  const handlePointerEnter = jest.fn()
-  const handlePointerLeave = jest.fn()
-  const {container} = render(
-    <div>
-      <button
-        onPointerEnter={handlePointerEnter}
-        onPointerLeave={handlePointerLeave}
-      />
-    </div>,
-  )
-  const button = container.firstChild.firstChild
-
-  fireEvent.pointerEnter(button)
-  expect(handlePointerEnter).toHaveBeenCalledTimes(1)
-
-  fireEvent.pointerLeave(button)
-  expect(handlePointerLeave).toHaveBeenCalledTimes(1)
-})
-
 test('calling `fireEvent` directly works too', () => {
   const handleEvent = jest.fn()
   const {
@@ -257,4 +257,22 @@ test('blur/foucs bubbles in react', () => {
   expect(handleBubbledBlur).toHaveBeenCalledTimes(1)
   expect(handleFocus).toHaveBeenCalledTimes(1)
   expect(handleBubbledFocus).toHaveBeenCalledTimes(1)
+})
+
+test('gotPointerCapture', () => {
+  const handlePointerCapture = jest.fn()
+  const {container} = render(
+    <button onGotPointerCapture={handlePointerCapture}>Button</button>,
+  )
+  const button = container.querySelector('button')
+
+  fireEvent(
+    button,
+    new MouseEvent('gotpointercapture', {
+      cancelable: true,
+      bubbles: true,
+    }),
+  )
+
+  expect(handlePointerCapture).toHaveBeenCalledTimes(1)
 })

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -63,10 +63,7 @@ const eventTypes = [
     elementType: 'button',
   },
   {
-    // PointerEvent isn't supported in JSDOM.
-    // We're using MouseEvent since PointerEvent extends it.
-    // type: 'Pointer',
-    type: 'Mouse',
+    type: 'Pointer',
     events: [
       'pointerOver',
       'pointerEnter',

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -76,9 +76,8 @@ const eventTypes = [
       'pointerCancel',
       'pointerOut',
       'pointerLeave',
-      // FIXME: Issue in dtl? Manual dispatch works in test "gotPointerCapture"
-      // 'gotPointerCapture',
-      // 'lostPointerCapture',
+      'gotPointerCapture',
+      'lostPointerCapture',
     ],
     elementType: 'button',
   },
@@ -257,22 +256,4 @@ test('blur/foucs bubbles in react', () => {
   expect(handleBubbledBlur).toHaveBeenCalledTimes(1)
   expect(handleFocus).toHaveBeenCalledTimes(1)
   expect(handleBubbledFocus).toHaveBeenCalledTimes(1)
-})
-
-test('gotPointerCapture', () => {
-  const handlePointerCapture = jest.fn()
-  const {container} = render(
-    <button onGotPointerCapture={handlePointerCapture}>Button</button>,
-  )
-  const button = container.querySelector('button')
-
-  fireEvent(
-    button,
-    new MouseEvent('gotpointercapture', {
-      cancelable: true,
-      bubbles: true,
-    }),
-  )
-
-  expect(handlePointerCapture).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Calling `fireEvent.gotPointerCapture` or `fireEvent.lostPointerCapture` should trigger their corresponding React event listeners.

**Why**:

Reveals issues with `gotpointercapture` and `lostpointerapture`

**How**:

- add all [pointer event types](https://www.w3.org/TR/pointerevents/#pointer-event-types) to our existing test suite
- [x] Bump `@testing-library/dom` to version including https://github.com/testing-library/dom-testing-library/pull/767

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~
- [x] Tests
- ~[ ] Typescript definitions updated~
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
