### PR TITLE
docs: update complex example

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ function Login() {
           password: passwordInput.value,
         }),
       })
-      .then(r => r.json())
+      .then((r) =>
+        r.json().then((data) => (r.ok ? data : Promise.reject(data)))
+      )
       .then(
         user => {
           setState({loading: false, resolved: true, error: null})
@@ -282,9 +284,10 @@ import {setupServer} from 'msw/node'
 import {render, fireEvent, screen} from '@testing-library/react'
 import Login from '../login'
 
+const fakeUserResponse = { token: 'fake_user_token' }
 const server = setupServer(
   rest.post('/api/login', (req, res, ctx) => {
-    return res(ctx.json({token: 'fake_user_token'}))
+    return res(ctx.json(fakeUserResponse))
   }),
 )
 
@@ -322,7 +325,7 @@ test('allows the user to login successfully', async () => {
 test('handles server exceptions', async () => {
   // mock the server error response for this test suite only.
   server.use(
-    rest.post('/', (req, res, ctx) => {
+    rest.post('/api/login', (req, res, ctx) => {
       return res(ctx.status(500), ctx.json({message: 'Internal server error'}))
     }),
   )


### PR DESCRIPTION
**What**: 
I update README.md complex example section. So, the test will be valid.
**Why**:
1) There was missing variable. 
2) I have seen that the promise always succeeds, so the tests always fail. The Promise returned from fetch() won’t reject on HTTP error status even if the response is an HTTP 404 or 500([reference](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)).

**How**:
I added the missing variable and fixed the promise to reject in case of `200<` status code.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) - N/A
- [ ] Tests - N/A
- [ ] Typescript definitions updated - N/A
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
