### PR TITLE
build: allow node latest build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
   allow_failures:
     - REACT_DIST=next
     - REACT_DIST=experimental
+    - node_js: node
   include:
     - stage: release
       node_js: 14


### PR DESCRIPTION
This is due to a braking change in npx adding a -y flag

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Allow node latest build to fail because of a [change](https://github.com/npm/cli/issues/1935) in npx requiring us to add a `-y` flag to our CI.

<!-- Why are these changes necessary? -->

**Why**: At the moment, our build is failing for Node 15.

<!-- How were these changes implemented? -->

**How**: Add the node latest version to the `allow_failures` section.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) - N/A
- [ ] Tests - N/A
- [ ] Typescript definitions updated - N/A
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

This was raised in this [comment](https://github.com/testing-library/react-testing-library/pull/806#issuecomment-716793552) by @kentcdodds.