### PR TITLE
Revert "chore: adjust .travis to install latest npm"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ env:
   - REACT_DIST=latest
   - REACT_DIST=next
   - REACT_DIST=experimental
-before_install:
-  - nvm install-latest-npm
 install:
+  # 7.0.6 fixed CI environments prompting user input.
+  # Can be removed once node15 bumps the shipped npm version.
+  - npm install --global npm@>=7.0.6
   - npm install
   # as requested by the React team :)
   # https://reactjs.org/blog/2019/10/22/react-release-channels.html#using-the-next-channel-for-integration-testing


### PR DESCRIPTION
Reverts testing-library/react-testing-library#812, which installs npm 6 not 7