### PR TITLE
fix: Return type of unmount is `void`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,7 +22,7 @@ export type RenderResult<Q extends Queries = typeof queries> = {
     options?: prettyFormat.OptionsReceived,
   ) => void
   rerender: (ui: React.ReactElement) => void
-  unmount: () => boolean
+  unmount: () => void
   asFragment: () => DocumentFragment
 } & {[P in keyof Q]: BoundFunction<Q[P]>}
 


### PR DESCRIPTION
https://github.com/testing-library/react-testing-library/issues/856


**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged

