### PR TITLE
fix(render): Default to HTMLElement in returned container

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,12 +6,16 @@ import {
   BoundFunction,
   prettyFormat,
 } from '@testing-library/dom'
+import {Renderer} from 'react-dom'
 import {act as reactAct} from 'react-dom/test-utils'
 
 export * from '@testing-library/dom'
 
-export type RenderResult<Q extends Queries = typeof queries> = {
-  container: Element
+export type RenderResult<
+  Q extends Queries = typeof queries,
+  Container extends Element | DocumentFragment = HTMLElement
+> = {
+  container: Container
   baseElement: Element
   debug: (
     baseElement?:
@@ -26,8 +30,11 @@ export type RenderResult<Q extends Queries = typeof queries> = {
   asFragment: () => DocumentFragment
 } & {[P in keyof Q]: BoundFunction<Q[P]>}
 
-export interface RenderOptions<Q extends Queries = typeof queries> {
-  container?: Element
+export interface RenderOptions<
+  Q extends Queries = typeof queries,
+  Container extends Element | DocumentFragment = HTMLElement
+> {
+  container?: Container
   baseElement?: Element
   hydrate?: boolean
   queries?: Q
@@ -43,10 +50,13 @@ export function render(
   ui: React.ReactElement,
   options?: Omit<RenderOptions, 'queries'>,
 ): RenderResult
-export function render<Q extends Queries>(
+export function render<
+  Q extends Queries,
+  Container extends Element | DocumentFragment = HTMLElement
+>(
   ui: React.ReactElement,
-  options: RenderOptions<Q>,
-): RenderResult<Q>
+  options: RenderOptions<Q, Container>,
+): RenderResult<Q, Container>
 
 /**
  * Unmounts React trees that were mounted with render.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,10 +46,6 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 /**
  * Render into a container which is appended to document.body. It should be used with cleanup.
  */
-export function render(
-  ui: React.ReactElement,
-  options?: Omit<RenderOptions, 'queries'>,
-): RenderResult
 export function render<
   Q extends Queries,
   Container extends Element | DocumentFragment = HTMLElement
@@ -57,6 +53,10 @@ export function render<
   ui: React.ReactElement,
   options: RenderOptions<Q, Container>,
 ): RenderResult<Q, Container>
+export function render(
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'queries'>,
+): RenderResult
 
 /**
  * Unmounts React trees that were mounted with render.

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -3,7 +3,7 @@ import {render, fireEvent, screen, waitFor} from '.'
 import * as pure from './pure'
 
 export async function testRender() {
-  const page = render(<div />)
+  const page = render(<button />)
 
   // single queries
   page.getByText('foo')
@@ -22,7 +22,7 @@ export async function testRender() {
 }
 
 export async function testPureRender() {
-  const page = pure.render(<div />)
+  const page = pure.render(<button />)
 
   // single queries
   page.getByText('foo')
@@ -43,8 +43,9 @@ export async function testPureRender() {
 export function testRenderOptions() {
   const container = document.createElement('div')
   const options = {container}
-  const {container: returnedContainer} = render(<div />, options)
-  // Unclear why TypeScript infers `HTMLElement` here when the the input `container` is `HTMLDivElement`
+  const {container: returnedContainer} = render(<button />, options)
+  // Unclear why TypeScript infers `HTMLElement` here when the the input `container` is `HTMLDivElement`.
+  // It's working for `testSVGRenderOptions`. 
   // Hopefully this breaks someday and we can switch to
   // expectType<HTMLDivElement, typeof returnedContainer>(returnedContainer)
   expectType<HTMLElement, typeof returnedContainer>(returnedContainer)
@@ -56,7 +57,7 @@ export function testSVGRenderOptions() {
     'svg',
   )
   const options = {container}
-  const {container: returnedContainer} = render(<svg />, options)
+  const {container: returnedContainer} = render(<path />, options)
   expectType<SVGSVGElement, typeof returnedContainer>(returnedContainer)
 }
 

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -44,11 +44,7 @@ export function testRenderOptions() {
   const container = document.createElement('div')
   const options = {container}
   const {container: returnedContainer} = render(<button />, options)
-  // Unclear why TypeScript infers `HTMLElement` here when the the input `container` is `HTMLDivElement`.
-  // It's working for `testSVGRenderOptions`. 
-  // Hopefully this breaks someday and we can switch to
-  // expectType<HTMLDivElement, typeof returnedContainer>(returnedContainer)
-  expectType<HTMLElement, typeof returnedContainer>(returnedContainer)
+  expectType<HTMLDivElement, typeof returnedContainer>(returnedContainer)
 }
 
 export function testSVGRenderOptions() {


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes https://github.com/testing-library/react-testing-library/pull/834#issuecomment-767796456

**Why**:

By default we create a `div` but declare that the type is `Element`. This is not specific enough for most use cases since e.g. `offsetHeight` isn't implemented in `Element`

**How**:

Adding a type parameter as anticipated in https://github.com/testing-library/react-testing-library/pull/833#issuecomment-730280641

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
