### PR TITLE
fix(render): add default type for Queries parameter

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,7 +47,7 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
  * Render into a container which is appended to document.body. It should be used with cleanup.
  */
 export function render<
-  Q extends Queries,
+  Q extends Queries = typeof queries,
   Container extends Element | DocumentFragment = HTMLElement
 >(
   ui: React.ReactElement,

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -84,6 +84,22 @@ export async function testWaitFor() {
   await waitFor(() => {})
 }
 
+export function testQueries() {
+  const {getByLabelText} = render(
+    <label htmlFor="usernameInput">Username</label>,
+  )
+  expectType<HTMLElement, ReturnType<typeof getByText>>(
+    getByLabelText('Username'),
+  )
+
+  const container = document.createElement('div')
+  const options = {container}
+  const {getByText} = render(<div>Hello World</div>, options)
+  expectType<HTMLElement, ReturnType<typeof getByText>>(
+    getByText('Hello World'),
+  )
+}
+
 /*
 eslint
   testing-library/prefer-explicit-assert: "off",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fixed type definition
<!-- Why are these changes necessary? -->

**Why**:

`v11.2.3`
```tsx
import { render, fireEvent } from '@testing-library/react'

const { getByText } = render(<div />, options)
fireEvent.click(getByText('foobaz')) // no type error
```

`v11.2.4`
```tsx
import { render, fireEvent } from '@testing-library/react'

const { getByText } = render(<div />, options)
fireEvent.click(getByText('foobaz')) // TS2345: Argument of type 'Error | HTMLElement | HTMLElement[] | Promise<HTMLElement[]> | Promise<HTMLElement> | null' is not assignable to parameter of type 'Element | Node | Window | Document'.
```

`v11.2.4-fixed`
```tsx
import { render, queries, fireEvent } from '@testing-library/react'

const { getByText } = render<typeof queries>(<div />, options)
fireEvent.click(getByText('foobaz')) //  no type error
```

`PR`
```tsx
import { render, fireEvent } from '@testing-library/react'

const { getByText } = render(<div />, options)
fireEvent.click(getByText('foobaz')) // no type error
```

<!-- How were these changes implemented? -->

**How**:
I added default type to render's first parameter

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
