### PR TITLE
[RFC] fix(fireEvent): Flush effects from discrete events immediately

### DIFF
--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -295,7 +295,7 @@ test.each([
     // There are two possible scenarios:
     // 1. If that effect is flushed during the click the native click listener would still receive the event that caused the native listener to be added.
     // 2. If that effect is flushed before we return from fireEvent.click the native click listener would not receive the event that caused the native listener to be added.
-    // React flushes effects scheduled from an update by a "discrete" event immediately.
+    // React flushes effects scheduled from an update by a "discrete" event immediately if that effect was scheduled from a portaled component.
     // but not effects in a batched context (e.g. act(() => {}))
     // So if we were in act(() => {}), we would see scenario 2 i.e. `onDocumentClick` would not be called
     // If we were not in `act(() => {})`, we would see scenario 1 i.e. `onDocumentClick` would already be called

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import {render, fireEvent} from '../'
+import {render, createEvent, fireEvent} from '../'
 
 const eventTypes = [
   {
@@ -256,49 +256,55 @@ test('blur/focus bubbles in react', () => {
   expect(handleBubbledFocus).toHaveBeenCalledTimes(1)
 })
 
-test('discrete events are not wrapped in act', () => {
-  function AddDocumentClickListener({onClick}) {
-    React.useEffect(() => {
-      document.addEventListener('click', onClick)
-      return () => {
-        document.removeEventListener('click', onClick)
-      }
-    }, [onClick])
-    return null
-  }
-  function Component({onDocumentClick}) {
-    const [open, setOpen] = React.useState(false)
+test.each([
+  ['fireEvent.click', element => fireEvent.click(element)],
+  ['fireEvent()', element => fireEvent(element, createEvent.click(element))],
+])(
+  'discrete events are not wrapped in act when using %s',
+  (_, dispatchClick) => {
+    function AddDocumentClickListener({onClick}) {
+      React.useEffect(() => {
+        document.addEventListener('click', onClick)
+        return () => {
+          document.removeEventListener('click', onClick)
+        }
+      }, [onClick])
+      return null
+    }
+    function Component({onDocumentClick}) {
+      const [open, setOpen] = React.useState(false)
 
-    return (
-      <React.Fragment>
-        <button onClick={() => setOpen(true)} />
-        {open &&
-          ReactDOM.createPortal(
-            <AddDocumentClickListener onClick={onDocumentClick} />,
-            document.body,
-          )}
-      </React.Fragment>
+      return (
+        <React.Fragment>
+          <button onClick={() => setOpen(true)} />
+          {open &&
+            ReactDOM.createPortal(
+              <AddDocumentClickListener onClick={onDocumentClick} />,
+              document.body,
+            )}
+        </React.Fragment>
+      )
+    }
+    const onDocumentClick = jest.fn()
+    render(<Component onDocumentClick={onDocumentClick} />)
+
+    const button = document.querySelector('button')
+    dispatchClick(button)
+
+    // We added a native click listener from an effect.
+    // There are two possible scenarios:
+    // 1. If that effect is flushed during the click the native click listener would still receive the event that caused the native listener to be added.
+    // 2. If that effect is flushed before we return from fireEvent.click the native click listener would not receive the event that caused the native listener to be added.
+    // React flushes effects scheduled from an update by a "discrete" event immediately.
+    // but not effects in a batched context (e.g. act(() => {}))
+    // So if we were in act(() => {}), we would see scenario 2 i.e. `onDocumentClick` would not be called
+    // If we were not in `act(() => {})`, we would see scenario 1 i.e. `onDocumentClick` would already be called
+    expect(onDocumentClick).toHaveBeenCalledTimes(1)
+
+    // verify we did actually flush the effect before we returned from `fireEvent.click` i.e. the native click listener is mounted.
+    document.dispatchEvent(
+      new MouseEvent('click', {bubbles: true, cancelable: true}),
     )
-  }
-  const onDocumentClick = jest.fn()
-  render(<Component onDocumentClick={onDocumentClick} />)
-
-  const button = document.querySelector('button')
-  fireEvent.click(button)
-
-  // We added a native click listener from an effect.
-  // There are two possible scenarios:
-  // 1. If that effect is flushed during the click the native click listener would still receive the event that caused the native listener to be added.
-  // 2. If that effect is flushed before we return from fireEvent.click the native click listener would not receive the event that caused the native listener to be added.
-  // React flushes effects scheduled from an update by a "discrete" event immediately.
-  // but not effects in a batched context (e.g. act(() => {}))
-  // So if we were in act(() => {}), we would see scenario 2 i.e. `onDocumentClick` would not be called
-  // If we were not in `act(() => {})`, we would see scenario 1 i.e. `onDocumentClick` would already be called
-  expect(onDocumentClick).toHaveBeenCalledTimes(1)
-
-  // verify we did actually flush the effect before we returned from `fireEvent.click` i.e. the native click listener is mounted.
-  document.dispatchEvent(
-    new MouseEvent('click', {bubbles: true, cancelable: true}),
-  )
-  expect(onDocumentClick).toHaveBeenCalledTimes(2)
-})
+    expect(onDocumentClick).toHaveBeenCalledTimes(2)
+  },
+)

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -58,9 +58,9 @@ function isDiscreteEvent(type) {
   return discreteEvents.has(type)
 }
 
-function noAct(cb) {
-  // Don't alter semantics of `cb`.
-  cb()
+function noAct(callback) {
+  // Don't alter semantics of `callback`.
+  callback()
   // But make sure updates are flushed before returning.
   act(() => {})
 }

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -59,7 +59,10 @@ function isDiscreteEvent(type) {
 }
 
 function noAct(cb) {
+  // Don't alter semantics of `cb`.
   cb()
+  // But make sure updates are flushed before returning.
+  act(() => {})
 }
 
 // react-testing-library's version of fireEvent will call

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -1,7 +1,59 @@
 import {fireEvent as dtlFireEvent} from '@testing-library/dom'
 import act from './act-compat'
 
-const discreteEvents = new Set()
+// https://github.com/facebook/react/blob/b48b38af68c27fd401fe4b923a8fa0b229693cd4/packages/react-dom/src/events/ReactDOMEventListener.js#L310-L366
+const discreteEvents = new Set([
+  'cancel',
+  'click',
+  'close',
+  'contextmenu',
+  'copy',
+  'cut',
+  'auxclick',
+  'dblclick',
+  'dragend',
+  'dragstart',
+  'drop',
+  'focusin',
+  'focusout',
+  'input',
+  'invalid',
+  'keydown',
+  'keypress',
+  'keyup',
+  'mousedown',
+  'mouseup',
+  'paste',
+  'pause',
+  'play',
+  'pointercancel',
+  'pointerdown',
+  'pointerup',
+  'ratechange',
+  'reset',
+  'seeked',
+  'submit',
+  'touchcancel',
+  'touchend',
+  'touchstart',
+  'volumechange',
+  'change',
+  'selectionchange',
+  'textInput',
+  'compositionstart',
+  'compositionend',
+  'compositionupdate',
+  'beforeblur',
+  'afterblur',
+  'beforeinput',
+  'blur',
+  'fullscreenchange',
+  'focus',
+  'hashchange',
+  'popstate',
+  'select',
+  'selectstart',
+])
 function isDiscreteEvent(type) {
   return discreteEvents.has(type)
 }
@@ -15,6 +67,9 @@ function noAct(cb) {
 // we make this distinction however is because we have
 // a few extra events that work a bit differently
 function fireEvent(element, event, ...args) {
+  // `act` would simulate how this event would behave if dispatched from a React event listener.
+  // In almost all cases we want to simulate how this event behaves in response to a user interaction.
+  // See discussion in https://github.com/facebook/react/pull/21202
   const eventWrapper = isDiscreteEvent(event.type) ? noAct : act
 
   let fireEventReturnValue
@@ -26,6 +81,9 @@ function fireEvent(element, event, ...args) {
 
 Object.keys(dtlFireEvent).forEach(key => {
   fireEvent[key] = (element, ...args) => {
+    // `act` would simulate how this event would behave if dispatched from a React event listener.
+    // In almost all cases we want to simulate how this event behaves in response to a user interaction.
+    // See discussion in https://github.com/facebook/react/pull/21202
     const eventWrapper = isDiscreteEvent(key.toLowerCase()) ? noAct : act
 
     let fireEventReturnValue

--- a/src/pure.js
+++ b/src/pure.js
@@ -16,13 +16,6 @@ configureDTL({
     })
     return result
   },
-  eventWrapper: cb => {
-    let result
-    act(() => {
-      result = cb()
-    })
-    return result
-  },
 })
 
 const mountedContainers = new Set()


### PR DESCRIPTION
I get strong enzyme vibes from this PR (considering we rely on React implementation details). This PR is more exploratory and any discussion should probably be directed at https://github.com/facebook/react/pull/21202 where I'd want this fix to land ideally.

**BREAKING CHANGE**
Importing from `@testing-library/react` will no longer wrap event
dispatches of `@testing-library/dom` in `act(() => {})`.

Essentially reverting https://github.com/testing-library/react-testing-library/pull/685. This will affect `user-event` but I don't see any other way. Wrapping in `act(() => {})` in `user-event` is event worse since `user-event` is explicitly about user events which `fireEevent.click` was not about.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

If effects in a portaled component were scheduled from discrete event dispatches (e.g. fireEevent.click) then these effects were not flushed during that event but before we returned. This behavior does not match the behavior of events in response to a user interaction.

**Why**:

`fireEvent` majority usage is to test event dispatches in response to user interactions.

**How**:

discrete events are no longer wrapped in `act(() => {})`. Their updates are still flushed when we return though.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
   I don't think we need to add docs since automatic `configure` was never documented
- [x] Tests
- ~[ ]~ Typescript definitions updated
- [ ] Ready to be merged
      PR must be revisited once https://github.com/facebook/react/pull/21202 is resolved.

<!-- feel free to add additional comments -->
