### PR TITLE
fix: Guard against `process` not being defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import {cleanup} from './pure'
 // this ensures that tests run in isolation from each other
 // if you don't like this then either import the `pure` module
 // or set the RTL_SKIP_AUTO_CLEANUP env variable to 'true'.
-if (!process.env.RTL_SKIP_AUTO_CLEANUP) {
+if (typeof process === "undefined" || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
   // ignore teardown() in code coverage because Jest does not support it
   /* istanbul ignore else */
   if (typeof afterEach === 'function') {


### PR DESCRIPTION
Hi all 👋
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes

```
ReferenceError: process is not defined
    at eval (webpack-internal:///./node_modules/@testing-library/react/dist/@testing-library/react.esm.js:458:1)
```

when @testing-library/react is being used with webpack 5 and karma.

<!-- Why are these changes necessary? -->

**Why**:

Webpack 5 doesn't shim Node's `process` object by default anymore. Only instances of `process.env.NODE_ENV` are replaced statically. This means that unguarded checks of `process.env` will crash in browser environments.

<!-- How were these changes implemented? -->

**How**:

I was wondering if there should also be a check in `dont-cleanup-after-each.js`. I decided against it since this would need to define a global `process` object in order to define the env variable. After all, it's the app developer's responsibility to provide a global `process` object in this case.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] Tests N/A
- [ ] Typescript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
