### PR TITLE
chore: Bump kcd-scripts to 11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@types/react-dom": "^17.0.0",
     "dotenv-cli": "^4.0.0",
-    "kcd-scripts": "^10.1.1",
+    "kcd-scripts": "^11.1.0",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@types/react-dom": "^17.0.0",
     "dotenv-cli": "^4.0.0",
-    "kcd-scripts": "^8.3.0",
+    "kcd-scripts": "^9.1.0",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -68,7 +68,10 @@
       "react/no-adjacent-inline-elements": "off",
       "import/no-unassigned-import": "off",
       "import/named": "off",
-      "testing-library/no-dom-import": "off"
+      "testing-library/no-container": "off",
+      "testing-library/no-dom-import": "off",
+      "testing-library/no-unnecessary-act": "off",
+      "testing-library/prefer-user-event": "off"
     }
   },
   "eslintIgnore": [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@types/react-dom": "^17.0.0",
     "dotenv-cli": "^4.0.0",
-    "kcd-scripts": "^9.1.0",
+    "kcd-scripts": "^10.1.1",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@types/react-dom": "^17.0.0",
     "dotenv-cli": "^4.0.0",
-    "kcd-scripts": "^7.5.1",
+    "kcd-scripts": "^8.3.0",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -54,14 +54,14 @@ describe('fake timers and missing act warnings', () => {
     jest.useRealTimers()
   })
 
-  test('cleanup does not flush immediates', () => {
+  test('cleanup does not flush microtasks', () => {
     const microTaskSpy = jest.fn()
     function Test() {
       const counter = 1
       const [, setDeferredCounter] = React.useState(null)
       React.useEffect(() => {
         let cancelled = false
-        setImmediate(() => {
+        Promise.resolve().then(() => {
           microTaskSpy()
           // eslint-disable-next-line jest/no-if -- false positive
           if (!cancelled) {
@@ -93,12 +93,12 @@ describe('fake timers and missing act warnings', () => {
       const [, setDeferredCounter] = React.useState(null)
       React.useEffect(() => {
         let cancelled = false
-        setImmediate(() => {
+        setTimeout(() => {
           deferredStateUpdateSpy()
           if (!cancelled) {
             setDeferredCounter(counter)
           }
-        })
+        }, 0)
 
         return () => {
           cancelled = true
@@ -109,7 +109,7 @@ describe('fake timers and missing act warnings', () => {
     }
     render(<Test />)
 
-    jest.runAllImmediates()
+    jest.runAllTimers()
     cleanup()
 
     expect(deferredStateUpdateSpy).toHaveBeenCalledTimes(1)

--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -63,6 +63,7 @@ describe('fake timers and missing act warnings', () => {
         let cancelled = false
         setImmediate(() => {
           microTaskSpy()
+          // eslint-disable-next-line jest/no-if -- false positive
           if (!cancelled) {
             setDeferredCounter(counter)
           }

--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -43,8 +43,8 @@ test('allows same arguments as prettyDOM', () => {
   expect(console.log).toHaveBeenCalledTimes(1)
   expect(console.log.mock.calls[0]).toMatchInlineSnapshot(`
     Array [
-      "<div>
-    ...",
+      <div>
+    ...,
     ]
   `)
 })

--- a/src/__tests__/new-act.js
+++ b/src/__tests__/new-act.js
@@ -49,7 +49,7 @@ test('async act recovers from errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)
@@ -67,7 +67,7 @@ test('async act recovers from sync errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)

--- a/src/__tests__/no-act.js
+++ b/src/__tests__/no-act.js
@@ -53,7 +53,7 @@ test('async act recovers from errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)
@@ -71,7 +71,7 @@ test('async act recovers from sync errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)

--- a/src/__tests__/no-act.js
+++ b/src/__tests__/no-act.js
@@ -2,7 +2,7 @@ let act, asyncAct
 
 beforeEach(() => {
   jest.resetModules()
-  act = require('..').act
+  act = require('../pure').act
   asyncAct = require('../act-compat').asyncAct
   jest.spyOn(console, 'error').mockImplementation(() => {})
 })

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -32,18 +32,18 @@ test('async act works even when the act is an old one', async () => {
     console.error('sigil')
   })
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "sigil",
-          ],
-          Array [
-            "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
-          ],
-          Array [
-            "sigil",
-          ],
-        ]
-    `)
+    Array [
+      Array [
+        sigil,
+      ],
+      Array [
+        It looks like you're using a version of react-dom that supports the "act" function, but not an awaitable version of "act" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.,
+      ],
+      Array [
+        sigil,
+      ],
+    ]
+  `)
   expect(callback).toHaveBeenCalledTimes(1)
 
   // and it doesn't warn you twice
@@ -71,10 +71,10 @@ test('async act recovers from async errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
+        It looks like you're using a version of react-dom that supports the "act" function, but not an awaitable version of "act" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.,
       ],
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)
@@ -92,7 +92,7 @@ test('async act recovers from sync errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)
@@ -109,11 +109,11 @@ test('async act can handle any sort of console.error', async () => {
     Array [
       Array [
         Object {
-          "error": "some error",
+          error: some error,
         },
       ],
       Array [
-        "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
+        It looks like you're using a version of react-dom that supports the "act" function, but not an awaitable version of "act" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.,
       ],
     ]
   `)

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -78,14 +78,14 @@ test('renders options.wrapper around node', () => {
 
   expect(screen.getByTestId('wrapper')).toBeInTheDocument()
   expect(container.firstChild).toMatchInlineSnapshot(`
-<div
-  data-testid="wrapper"
->
-  <div
-    data-testid="inner"
-  />
-</div>
-`)
+    <div
+      data-testid=wrapper
+    >
+      <div
+        data-testid=inner
+      />
+    </div>
+  `)
 })
 
 test('flushes useEffect cleanup functions sync on unmount()', () => {

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -3,39 +3,39 @@ import {render, fireEvent, screen, waitFor} from '.'
 import * as pure from './pure'
 
 export async function testRender() {
-  const page = render(<button />)
+  const view = render(<button />)
 
   // single queries
-  page.getByText('foo')
-  page.queryByText('foo')
-  await page.findByText('foo')
+  view.getByText('foo')
+  view.queryByText('foo')
+  await view.findByText('foo')
 
   // multiple queries
-  page.getAllByText('bar')
-  page.queryAllByText('bar')
-  await page.findAllByText('bar')
+  view.getAllByText('bar')
+  view.queryAllByText('bar')
+  await view.findAllByText('bar')
 
   // helpers
-  const {container, rerender, debug} = page
+  const {container, rerender, debug} = view
   expectType<HTMLElement, typeof container>(container)
   return {container, rerender, debug}
 }
 
 export async function testPureRender() {
-  const page = pure.render(<button />)
+  const view = pure.render(<button />)
 
   // single queries
-  page.getByText('foo')
-  page.queryByText('foo')
-  await page.findByText('foo')
+  view.getByText('foo')
+  view.queryByText('foo')
+  await view.findByText('foo')
 
   // multiple queries
-  page.getAllByText('bar')
-  page.queryAllByText('bar')
-  await page.findAllByText('bar')
+  view.getAllByText('bar')
+  view.queryAllByText('bar')
+  await view.findAllByText('bar')
 
   // helpers
-  const {container, rerender, debug} = page
+  const {container, rerender, debug} = view
   expectType<HTMLElement, typeof container>(container)
   return {container, rerender, debug}
 }


### PR DESCRIPTION
Targetting `alpha` since `@testing-library/dom@latest` is not compatible with jest 27

**What**:

Update `npm run validate` dependencies

**Why**:

To stay up-to-date with latest dependencies

**How**:

Bump `kcd-scripts` incrementally up until 11.x. Each commits bumps by a major so review by commit is advised.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
