### PR TITLE
fix: Bump testing-library/dom to v8 alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^7.28.1"
+    "@testing-library/dom": "^8.0.0-alpha.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",


### PR DESCRIPTION
BREAKING CHANGE: Bumps `@testing-library/dom` to 8.0.0-alpha.3.

For a comprehensive list of breaking changes see the individual releases:
- https://github.com/testing-library/dom-testing-library/releases/tag/v8.0.0-alpha.1
- https://github.com/testing-library/dom-testing-library/releases/tag/v8.0.0-alpha.2
- https://github.com/testing-library/dom-testing-library/releases/tag/v8.0.0-alpha.3

**What**:

<!-- Why are these changes necessary? -->

**Why**:

To propagate all the fixes/features from `@testing-library/dom`

**How**:

Bump `@testing-library/dom` to 8.0.0-alpha.3. The stable release of /react@12.x will use the stable release of /dom@8.x

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ Tests
- ~[ ]~ Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
