### PR TITLE
test: Ignore React 18 legacy root deprecation warnings

### DIFF
--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -83,7 +83,10 @@ describe('fake timers and missing act warnings', () => {
     expect(microTaskSpy).toHaveBeenCalledTimes(0)
     // console.error is mocked
     // eslint-disable-next-line no-console
-    expect(console.error).toHaveBeenCalledTimes(0)
+    expect(console.error).toHaveBeenCalledTimes(
+      // ReactDOM.render is deprecated in React 18
+      React.version.startsWith('18') ? 1 : 0,
+    )
   })
 
   test('cleanup does not swallow missing act warnings', () => {
@@ -115,10 +118,16 @@ describe('fake timers and missing act warnings', () => {
     expect(deferredStateUpdateSpy).toHaveBeenCalledTimes(1)
     // console.error is mocked
     // eslint-disable-next-line no-console
-    expect(console.error).toHaveBeenCalledTimes(1)
-    // eslint-disable-next-line no-console
-    expect(console.error.mock.calls[0][0]).toMatch(
-      'a test was not wrapped in act(...)',
+    expect(console.error).toHaveBeenCalledTimes(
+      // ReactDOM.render is deprecated in React 18
+      React.version.startsWith('18') ? 2 : 1,
     )
+    // eslint-disable-next-line no-console
+    expect(
+      console.error.mock.calls[
+        // ReactDOM.render is deprecated in React 18
+        React.version.startsWith('18') ? 1 : 0
+      ][0],
+    ).toMatch('a test was not wrapped in act(...)')
   })
 })

--- a/src/__tests__/new-act.js
+++ b/src/__tests__/new-act.js
@@ -1,4 +1,4 @@
-let asyncAct
+let asyncAct, consoleErrorMock
 
 jest.mock('react-dom/test-utils', () => ({
   act: cb => {
@@ -9,11 +9,11 @@ jest.mock('react-dom/test-utils', () => ({
 beforeEach(() => {
   jest.resetModules()
   asyncAct = require('../act-compat').asyncAct
-  jest.spyOn(console, 'error').mockImplementation(() => {})
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
 afterEach(() => {
-  console.error.mockRestore()
+  consoleErrorMock.mockRestore()
 })
 
 test('async act works when it does not exist (older versions of react)', async () => {

--- a/src/__tests__/no-act.js
+++ b/src/__tests__/no-act.js
@@ -1,15 +1,15 @@
-let act, asyncAct, React
+let act, asyncAct, React, consoleErrorMock
 
 beforeEach(() => {
   jest.resetModules()
   act = require('../pure').act
   asyncAct = require('../act-compat').asyncAct
   React = require('react')
-  jest.spyOn(console, 'error').mockImplementation(() => {})
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
 afterEach(() => {
-  console.error.mockRestore()
+  consoleErrorMock.mockRestore()
 })
 
 jest.mock('react-dom/test-utils', () => ({}))

--- a/src/__tests__/no-act.js
+++ b/src/__tests__/no-act.js
@@ -1,9 +1,10 @@
-let act, asyncAct
+let act, asyncAct, React
 
 beforeEach(() => {
   jest.resetModules()
   act = require('../pure').act
   asyncAct = require('../act-compat').asyncAct
+  React = require('react')
   jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
@@ -17,7 +18,10 @@ test('act works even when there is no act from test utils', () => {
   const callback = jest.fn()
   act(callback)
   expect(callback).toHaveBeenCalledTimes(1)
-  expect(console.error).toHaveBeenCalledTimes(0)
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 1 : 0,
+  )
 })
 
 test('async act works when it does not exist (older versions of react)', async () => {
@@ -26,7 +30,10 @@ test('async act works when it does not exist (older versions of react)', async (
     await Promise.resolve()
     await callback()
   })
-  expect(console.error).toHaveBeenCalledTimes(0)
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 2 : 0,
+  )
   expect(callback).toHaveBeenCalledTimes(1)
 
   callback.mockClear()
@@ -36,7 +43,10 @@ test('async act works when it does not exist (older versions of react)', async (
     await Promise.resolve()
     await callback()
   })
-  expect(console.error).toHaveBeenCalledTimes(0)
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 2 : 0,
+  )
   expect(callback).toHaveBeenCalledTimes(1)
 })
 
@@ -49,14 +59,16 @@ test('async act recovers from errors', async () => {
   } catch (err) {
     console.error('call console.error')
   }
-  expect(console.error).toHaveBeenCalledTimes(1)
-  expect(console.error.mock.calls).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        call console.error,
-      ],
-    ]
-  `)
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 2 : 1,
+  )
+  expect(
+    console.error.mock.calls[
+      // ReactDOM.render is deprecated in React 18
+      React.version.startsWith('18') ? 1 : 0
+    ][0],
+  ).toMatch('call console.error')
 })
 
 test('async act recovers from sync errors', async () => {

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -1,13 +1,13 @@
-let asyncAct
+let asyncAct, consoleErrorMock
 
 beforeEach(() => {
   jest.resetModules()
   asyncAct = require('../act-compat').asyncAct
-  jest.spyOn(console, 'error').mockImplementation(() => {})
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
 afterEach(() => {
-  console.error.mockRestore()
+  consoleErrorMock.mockRestore()
 })
 
 jest.mock('react-dom/test-utils', () => ({

--- a/src/__tests__/stopwatch.js
+++ b/src/__tests__/stopwatch.js
@@ -53,5 +53,8 @@ test('unmounts a component', async () => {
   // and get an error.
   await sleep(5)
   // eslint-disable-next-line no-console
-  expect(console.error).not.toHaveBeenCalled()
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 1 : 0,
+  )
 })

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,1 +1,21 @@
 import '@testing-library/jest-dom/extend-expect'
+
+beforeEach(() => {
+  const originalConsoleError = console.error
+  jest
+    .spyOn(console, 'error')
+    .mockImplementation((message, ...optionalParams) => {
+      // Ignore ReactDOM.render/ReactDOM.hydrate deprecation warning
+      if (message.indexOf('Use createRoot instead.') !== -1) {
+        return
+      }
+      originalConsoleError(message, ...optionalParams)
+    })
+})
+
+afterEach(() => {
+  // maybe another test already restore console error mocks
+  if (typeof console.error.mockRestore === 'function') {
+    console.error.mockRestore()
+  }
+})

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,8 +1,10 @@
 import '@testing-library/jest-dom/extend-expect'
 
+let consoleErrorMock
+
 beforeEach(() => {
   const originalConsoleError = console.error
-  jest
+  consoleErrorMock = jest
     .spyOn(console, 'error')
     .mockImplementation((message, ...optionalParams) => {
       // Ignore ReactDOM.render/ReactDOM.hydrate deprecation warning
@@ -14,8 +16,5 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  // maybe another test already restore console error mocks
-  if (typeof console.error.mockRestore === 'function') {
-    console.error.mockRestore()
-  }
+  consoleErrorMock.mockRestore()
 })


### PR DESCRIPTION
Forward port https://github.com/testing-library/react-testing-library/pull/928 to `alpha`