### PR TITLE
feat: Drop support for node 10

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,4 @@
 {
-  "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"]
+  "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
+  "node": "12"
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
     strategy:
       matrix:
-        node: [10.13, 12, 14, 16]
+        node: [12, 14, 16]
         react: [latest, next, experimental]
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "types/index.d.ts",
   "module": "dist/@testing-library/react.esm.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
BREAKING CHANGE: node 10 is no longer supported. It reached its end-of-life on 30.04.2021.

**What**:

Closes https://github.com/testing-library/react-testing-library/issues/913
Closes https://github.com/testing-library/react-testing-library/pull/927

**Why**:

Reduces maintenance burden

**How**:

Change `engines` field to require `node>=12`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
	 Will do once we release the alpha
- [x] Tests
- ~[ ]~ Typescript definitions updated
- [ ] Ready to be merged

