### PR TITLE
fix: Update @testing-library/dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^8.0.0-alpha.3"
+    "@testing-library/dom": "^8.0.0-alpha.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",


### PR DESCRIPTION
Closes https://github.com/testing-library/react-testing-library/issues/918

BREAKING CHANGE: Remove `waitForElement`. `<style />`, `<script />` and comment nodes are now ignored by default in `pretty-dom`.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Remove `waitForElement` https://github.com/testing-library/dom-testing-library/pull/969
- Add `filterNode` to `pretty-dom` https://github.com/testing-library/dom-testing-library/pull/907

**Why**:

Propagate changes in /dom to /react users

**How**:

Bump `@testing-library/dom` to latest `alpha`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
