### PR TITLE
chore: Release v12 as stable

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,4 @@
 {
-  "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"]
+  "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
+  "node": "12"
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
     strategy:
       matrix:
-        node: [10.13, 12, 14, 16]
+        node: [12, 14, 16]
         react: [latest, next, experimental]
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@types/react-dom": "^17.0.0",
     "dotenv-cli": "^4.0.0",
-    "kcd-scripts": "^7.5.1",
+    "kcd-scripts": "^11.1.0",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -68,7 +68,10 @@
       "react/no-adjacent-inline-elements": "off",
       "import/no-unassigned-import": "off",
       "import/named": "off",
-      "testing-library/no-dom-import": "off"
+      "testing-library/no-container": "off",
+      "testing-library/no-dom-import": "off",
+      "testing-library/no-unnecessary-act": "off",
+      "testing-library/prefer-user-event": "off"
     }
   },
   "eslintIgnore": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^8.0.0-alpha.6"
+    "@testing-library/dom": "^8.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^7.28.1"
+    "@testing-library/dom": "^8.0.0-alpha.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^8.0.0-alpha.3"
+    "@testing-library/dom": "^8.0.0-alpha.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "types/index.d.ts",
   "module": "dist/@testing-library/react.esm.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "prebuild": "rimraf dist",

--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -54,15 +54,16 @@ describe('fake timers and missing act warnings', () => {
     jest.useRealTimers()
   })
 
-  test('cleanup does not flush immediates', () => {
+  test('cleanup does not flush microtasks', () => {
     const microTaskSpy = jest.fn()
     function Test() {
       const counter = 1
       const [, setDeferredCounter] = React.useState(null)
       React.useEffect(() => {
         let cancelled = false
-        setImmediate(() => {
+        Promise.resolve().then(() => {
           microTaskSpy()
+          // eslint-disable-next-line jest/no-if -- false positive
           if (!cancelled) {
             setDeferredCounter(counter)
           }
@@ -92,12 +93,12 @@ describe('fake timers and missing act warnings', () => {
       const [, setDeferredCounter] = React.useState(null)
       React.useEffect(() => {
         let cancelled = false
-        setImmediate(() => {
+        setTimeout(() => {
           deferredStateUpdateSpy()
           if (!cancelled) {
             setDeferredCounter(counter)
           }
-        })
+        }, 0)
 
         return () => {
           cancelled = true
@@ -108,7 +109,7 @@ describe('fake timers and missing act warnings', () => {
     }
     render(<Test />)
 
-    jest.runAllImmediates()
+    jest.runAllTimers()
     cleanup()
 
     expect(deferredStateUpdateSpy).toHaveBeenCalledTimes(1)

--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -83,7 +83,10 @@ describe('fake timers and missing act warnings', () => {
     expect(microTaskSpy).toHaveBeenCalledTimes(0)
     // console.error is mocked
     // eslint-disable-next-line no-console
-    expect(console.error).toHaveBeenCalledTimes(0)
+    expect(console.error).toHaveBeenCalledTimes(
+      // ReactDOM.render is deprecated in React 18
+      React.version.startsWith('18') ? 1 : 0,
+    )
   })
 
   test('cleanup does not swallow missing act warnings', () => {
@@ -115,10 +118,16 @@ describe('fake timers and missing act warnings', () => {
     expect(deferredStateUpdateSpy).toHaveBeenCalledTimes(1)
     // console.error is mocked
     // eslint-disable-next-line no-console
-    expect(console.error).toHaveBeenCalledTimes(1)
-    // eslint-disable-next-line no-console
-    expect(console.error.mock.calls[0][0]).toMatch(
-      'a test was not wrapped in act(...)',
+    expect(console.error).toHaveBeenCalledTimes(
+      // ReactDOM.render is deprecated in React 18
+      React.version.startsWith('18') ? 2 : 1,
     )
+    // eslint-disable-next-line no-console
+    expect(
+      console.error.mock.calls[
+        // ReactDOM.render is deprecated in React 18
+        React.version.startsWith('18') ? 1 : 0
+      ][0],
+    ).toMatch('a test was not wrapped in act(...)')
   })
 })

--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -43,8 +43,8 @@ test('allows same arguments as prettyDOM', () => {
   expect(console.log).toHaveBeenCalledTimes(1)
   expect(console.log.mock.calls[0]).toMatchInlineSnapshot(`
     Array [
-      "<div>
-    ...",
+      <div>
+    ...,
     ]
   `)
 })

--- a/src/__tests__/new-act.js
+++ b/src/__tests__/new-act.js
@@ -1,4 +1,4 @@
-let asyncAct
+let asyncAct, consoleErrorMock
 
 jest.mock('react-dom/test-utils', () => ({
   act: cb => {
@@ -9,11 +9,11 @@ jest.mock('react-dom/test-utils', () => ({
 beforeEach(() => {
   jest.resetModules()
   asyncAct = require('../act-compat').asyncAct
-  jest.spyOn(console, 'error').mockImplementation(() => {})
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
 afterEach(() => {
-  console.error.mockRestore()
+  consoleErrorMock.mockRestore()
 })
 
 test('async act works when it does not exist (older versions of react)', async () => {

--- a/src/__tests__/new-act.js
+++ b/src/__tests__/new-act.js
@@ -49,7 +49,7 @@ test('async act recovers from errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)
@@ -67,7 +67,7 @@ test('async act recovers from sync errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)

--- a/src/__tests__/no-act.js
+++ b/src/__tests__/no-act.js
@@ -2,7 +2,7 @@ let act, asyncAct
 
 beforeEach(() => {
   jest.resetModules()
-  act = require('..').act
+  act = require('../pure').act
   asyncAct = require('../act-compat').asyncAct
   jest.spyOn(console, 'error').mockImplementation(() => {})
 })
@@ -53,7 +53,7 @@ test('async act recovers from errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)
@@ -71,7 +71,7 @@ test('async act recovers from sync errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)

--- a/src/__tests__/no-act.js
+++ b/src/__tests__/no-act.js
@@ -1,14 +1,15 @@
-let act, asyncAct
+let act, asyncAct, React, consoleErrorMock
 
 beforeEach(() => {
   jest.resetModules()
   act = require('../pure').act
   asyncAct = require('../act-compat').asyncAct
-  jest.spyOn(console, 'error').mockImplementation(() => {})
+  React = require('react')
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
 afterEach(() => {
-  console.error.mockRestore()
+  consoleErrorMock.mockRestore()
 })
 
 jest.mock('react-dom/test-utils', () => ({}))
@@ -17,7 +18,10 @@ test('act works even when there is no act from test utils', () => {
   const callback = jest.fn()
   act(callback)
   expect(callback).toHaveBeenCalledTimes(1)
-  expect(console.error).toHaveBeenCalledTimes(0)
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 1 : 0,
+  )
 })
 
 test('async act works when it does not exist (older versions of react)', async () => {
@@ -26,7 +30,10 @@ test('async act works when it does not exist (older versions of react)', async (
     await Promise.resolve()
     await callback()
   })
-  expect(console.error).toHaveBeenCalledTimes(0)
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 2 : 0,
+  )
   expect(callback).toHaveBeenCalledTimes(1)
 
   callback.mockClear()
@@ -36,7 +43,10 @@ test('async act works when it does not exist (older versions of react)', async (
     await Promise.resolve()
     await callback()
   })
-  expect(console.error).toHaveBeenCalledTimes(0)
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 2 : 0,
+  )
   expect(callback).toHaveBeenCalledTimes(1)
 })
 
@@ -49,14 +59,16 @@ test('async act recovers from errors', async () => {
   } catch (err) {
     console.error('call console.error')
   }
-  expect(console.error).toHaveBeenCalledTimes(1)
-  expect(console.error.mock.calls).toMatchInlineSnapshot(`
-    Array [
-      Array [
-        call console.error,
-      ],
-    ]
-  `)
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 2 : 1,
+  )
+  expect(
+    console.error.mock.calls[
+      // ReactDOM.render is deprecated in React 18
+      React.version.startsWith('18') ? 1 : 0
+    ][0],
+  ).toMatch('call console.error')
 })
 
 test('async act recovers from sync errors', async () => {

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -32,18 +32,18 @@ test('async act works even when the act is an old one', async () => {
     console.error('sigil')
   })
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            "sigil",
-          ],
-          Array [
-            "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
-          ],
-          Array [
-            "sigil",
-          ],
-        ]
-    `)
+    Array [
+      Array [
+        sigil,
+      ],
+      Array [
+        It looks like you're using a version of react-dom that supports the "act" function, but not an awaitable version of "act" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.,
+      ],
+      Array [
+        sigil,
+      ],
+    ]
+  `)
   expect(callback).toHaveBeenCalledTimes(1)
 
   // and it doesn't warn you twice
@@ -71,10 +71,10 @@ test('async act recovers from async errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
+        It looks like you're using a version of react-dom that supports the "act" function, but not an awaitable version of "act" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.,
       ],
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)
@@ -92,7 +92,7 @@ test('async act recovers from sync errors', async () => {
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
     Array [
       Array [
-        "call console.error",
+        call console.error,
       ],
     ]
   `)
@@ -109,11 +109,11 @@ test('async act can handle any sort of console.error', async () => {
     Array [
       Array [
         Object {
-          "error": "some error",
+          error: some error,
         },
       ],
       Array [
-        "It looks like you're using a version of react-dom that supports the \\"act\\" function, but not an awaitable version of \\"act\\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.",
+        It looks like you're using a version of react-dom that supports the "act" function, but not an awaitable version of "act" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.,
       ],
     ]
   `)

--- a/src/__tests__/old-act.js
+++ b/src/__tests__/old-act.js
@@ -1,13 +1,13 @@
-let asyncAct
+let asyncAct, consoleErrorMock
 
 beforeEach(() => {
   jest.resetModules()
   asyncAct = require('../act-compat').asyncAct
-  jest.spyOn(console, 'error').mockImplementation(() => {})
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
 afterEach(() => {
-  console.error.mockRestore()
+  consoleErrorMock.mockRestore()
 })
 
 jest.mock('react-dom/test-utils', () => ({

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -78,14 +78,14 @@ test('renders options.wrapper around node', () => {
 
   expect(screen.getByTestId('wrapper')).toBeInTheDocument()
   expect(container.firstChild).toMatchInlineSnapshot(`
-<div
-  data-testid="wrapper"
->
-  <div
-    data-testid="inner"
-  />
-</div>
-`)
+    <div
+      data-testid=wrapper
+    >
+      <div
+        data-testid=inner
+      />
+    </div>
+  `)
 })
 
 test('flushes useEffect cleanup functions sync on unmount()', () => {

--- a/src/__tests__/stopwatch.js
+++ b/src/__tests__/stopwatch.js
@@ -53,5 +53,8 @@ test('unmounts a component', async () => {
   // and get an error.
   await sleep(5)
   // eslint-disable-next-line no-console
-  expect(console.error).not.toHaveBeenCalled()
+  expect(console.error).toHaveBeenCalledTimes(
+    // ReactDOM.render is deprecated in React 18
+    React.version.startsWith('18') ? 1 : 0,
+  )
 })

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,1 +1,20 @@
 import '@testing-library/jest-dom/extend-expect'
+
+let consoleErrorMock
+
+beforeEach(() => {
+  const originalConsoleError = console.error
+  consoleErrorMock = jest
+    .spyOn(console, 'error')
+    .mockImplementation((message, ...optionalParams) => {
+      // Ignore ReactDOM.render/ReactDOM.hydrate deprecation warning
+      if (message.indexOf('Use createRoot instead.') !== -1) {
+        return
+      }
+      originalConsoleError(message, ...optionalParams)
+    })
+})
+
+afterEach(() => {
+  consoleErrorMock.mockRestore()
+})

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -3,39 +3,39 @@ import {render, fireEvent, screen, waitFor} from '.'
 import * as pure from './pure'
 
 export async function testRender() {
-  const page = render(<button />)
+  const view = render(<button />)
 
   // single queries
-  page.getByText('foo')
-  page.queryByText('foo')
-  await page.findByText('foo')
+  view.getByText('foo')
+  view.queryByText('foo')
+  await view.findByText('foo')
 
   // multiple queries
-  page.getAllByText('bar')
-  page.queryAllByText('bar')
-  await page.findAllByText('bar')
+  view.getAllByText('bar')
+  view.queryAllByText('bar')
+  await view.findAllByText('bar')
 
   // helpers
-  const {container, rerender, debug} = page
+  const {container, rerender, debug} = view
   expectType<HTMLElement, typeof container>(container)
   return {container, rerender, debug}
 }
 
 export async function testPureRender() {
-  const page = pure.render(<button />)
+  const view = pure.render(<button />)
 
   // single queries
-  page.getByText('foo')
-  page.queryByText('foo')
-  await page.findByText('foo')
+  view.getByText('foo')
+  view.queryByText('foo')
+  await view.findByText('foo')
 
   // multiple queries
-  page.getAllByText('bar')
-  page.queryAllByText('bar')
-  await page.findAllByText('bar')
+  view.getAllByText('bar')
+  view.queryAllByText('bar')
+  await view.findAllByText('bar')
 
   // helpers
-  const {container, rerender, debug} = page
+  const {container, rerender, debug} = view
   expectType<HTMLElement, typeof container>(container)
   return {container, rerender, debug}
 }


### PR DESCRIPTION
BREAKING CHANGE: Bump `@testing-library/dom` to 8.0.0. Please check out the [`@testing-library/dom@8.0.0` release page](https://github.com/testing-library/dom-testing-library/releases/tag/v8.0.0) for a detailed list of breaking changes.

BREAKING CHANGE: node 10 is no longer supported. It reached its end-of-life on 30.04.2021.

**What**:

Propagate fixes and features from latest `@testing-library/dom` major

**Why**:

- up to date with latest fixes/features
- especially clock related changes are important to debug concurrent react testing better and ensure compat with jest 27

**How**:

Bump `@testing-library/dom` to latest

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] Typescript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
