### PR TITLE
Add mocha-watch-cleanup-after-each Mocha hook

### DIFF
--- a/mocha-cleanup-after-each.js
+++ b/mocha-cleanup-after-each.js
@@ -1,0 +1,8 @@
+require('./dont-cleanup-after-each')
+const rtl = require('./')
+
+exports.mochaHooks = {
+  afterEach() {
+    rtl.cleanup()
+  },
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "files": [
     "dist",
     "dont-cleanup-after-each.js",
+    "mocha-cleanup-after-each.js",
     "pure.js",
     "pure.d.ts",
     "types/*.d.ts"


### PR DESCRIPTION
**What**: Added a hook which can be used in Mocha's watch mode to do automated cleanup in tests, based on discussion in https://github.com/testing-library/testing-library-docs/pull/887

<!-- Why are these changes necessary? -->

**Why**: Without manual cleanup, or a custom root hook, running tests written using react-testing-library using Mocha results in test fails, as no cleanup is done by react-testing-library on subsequent runs, so elements from previous runs remain in the DOM.

<!-- How were these changes implemented? -->

**How**: Added a Mocha root hook which runs cleanup. The hook can be used when running `mocha --watch` (or `mocha` without watch).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs): https://github.com/testing-library/testing-library-docs/pull/887
- [ ] Tests - I don't believe I can add any automated test without also adding mocha, which I don't think is desired. Anyway, I've tested the change locally in a project I have mocha set up in and it works great.
- [ ] TypeScript definitions updated - N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
