### PR TITLE
fix(TS): make wrapper allow a simple function comp

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -70,7 +70,7 @@ export interface RenderOptions<
    *
    *  @see https://testing-library.com/docs/react-testing-library/api/#wrapper
    */
-  wrapper?: React.ComponentType | (props: {children: React.ReactNode}) => JSX.Element
+  wrapper?: React.ComponentType | ((props: {children: React.ReactNode}) => JSX.Element)
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,6 @@ import {
   BoundFunction,
   prettyFormat,
 } from '@testing-library/dom'
-import React from 'react'
 import {Renderer} from 'react-dom'
 import {act as reactAct} from 'react-dom/test-utils'
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,7 @@ import {
   BoundFunction,
   prettyFormat,
 } from '@testing-library/dom'
+import React from 'react'
 import {Renderer} from 'react-dom'
 import {act as reactAct} from 'react-dom/test-utils'
 
@@ -70,9 +71,7 @@ export interface RenderOptions<
    *
    *  @see https://testing-library.com/docs/react-testing-library/api/#wrapper
    */
-  wrapper?:
-    | React.ComponentType
-    | ((props: {children: React.ReactNode}) => JSX.Element)
+  wrapper?: React.ComponentType<{children: React.ReactElement}>
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -70,7 +70,7 @@ export interface RenderOptions<
    *
    *  @see https://testing-library.com/docs/react-testing-library/api/#wrapper
    */
-  wrapper?: React.ComponentType
+  wrapper?: React.ComponentType | (props: {children: React.ReactNode}) => JSX.Element
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -70,7 +70,9 @@ export interface RenderOptions<
    *
    *  @see https://testing-library.com/docs/react-testing-library/api/#wrapper
    */
-  wrapper?: React.ComponentType | ((props: {children: React.ReactNode}) => JSX.Element)
+  wrapper?:
+    | React.ComponentType
+    | ((props: {children: React.ReactNode}) => JSX.Element)
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -111,6 +111,17 @@ export function wrappedRender(
   return pure.render(ui, {wrapper: Wrapper, ...options})
 }
 
+export function wrappedRenderB(
+  ui: React.ReactElement,
+  options?: pure.RenderOptions,
+) {
+  const Wrapper: React.FunctionComponent = ({children}) => {
+    return <div>{children}</div>
+  }
+
+  return pure.render(ui, {wrapper: Wrapper, ...options})
+}
+
 /*
 eslint
   testing-library/prefer-explicit-assert: "off",

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -100,6 +100,17 @@ export function testQueries() {
   )
 }
 
+export function wrappedRender(
+  ui: React.ReactElement,
+  options?: pure.RenderOptions,
+) {
+  const Wrapper = ({children}: {children: React.ReactElement}): JSX.Element => {
+    return <div>{children}</div>
+  }
+
+  return pure.render(ui, {wrapper: Wrapper, ...options})
+}
+
 /*
 eslint
   testing-library/prefer-explicit-assert: "off",


### PR DESCRIPTION
**What**: This adds an option for the wrapper to use a simple function component

<!-- Why are these changes necessary? -->

**Why**: Closes #965

<!-- How were these changes implemented? -->

**How**: Added the option to the types for `render`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
