### PR TITLE
fix(render): Don't reject wrapper types based on statics

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -70,7 +70,7 @@ export interface RenderOptions<
    *
    *  @see https://testing-library.com/docs/react-testing-library/api/#wrapper
    */
-  wrapper?: React.ComponentType<{children: React.ReactElement}>
+  wrapper?: React.JSXElementConstructor<{children: React.ReactElement}>
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -115,7 +115,9 @@ export function wrappedRenderB(
   ui: React.ReactElement,
   options?: pure.RenderOptions,
 ) {
-  const Wrapper: React.FunctionComponent = ({children}) => {
+  const Wrapper: React.FunctionComponent<{children?: React.ReactNode}> = ({
+    children,
+  }) => {
     return <div>{children}</div>
   }
 

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -124,6 +124,23 @@ export function wrappedRenderB(
   return pure.render(ui, {wrapper: Wrapper, ...options})
 }
 
+export function wrappedRenderC(
+  ui: React.ReactElement,
+  options?: pure.RenderOptions,
+) {
+  interface AppWrapperProps {
+    userProviderProps?: {user: string}
+  }
+  const AppWrapperProps: React.FunctionComponent<AppWrapperProps> = ({
+    children,
+    userProviderProps = {user: 'TypeScript'},
+  }) => {
+    return <div data-testid={userProviderProps.user}>{children}</div>
+  }
+
+  return pure.render(ui, {wrapper: AppWrapperProps, ...options})
+}
+
 /*
 eslint
   testing-library/prefer-explicit-assert: "off",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes https://github.com/testing-library/react-testing-library/issues/970
Closes https://github.com/testing-library/react-testing-library/issues/972

**Why**:

Broke in https://github.com/testing-library/react-testing-library/pull/966

**How**:

Implicit children strikes yet again. While `FunctionComponent` adds implicit children, its `propTypes` do not so we didn't catch that issue. We don't care about React statics and just that we can pass it to `createElement` (or any JSX runtime). 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
