### PR TITLE
fix(render): Actually hydrate with given ui

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,10 +6,10 @@ module.exports = Object.assign(jestConfig, {
     // full coverage across the build matrix (React 17, 18) but not in a single job
     './src/pure': {
       // minimum coverage of jobs using React 17 and 18
-      branches: 80,
+      branches: 75,
       functions: 78,
-      lines: 79,
-      statements: 79,
+      lines: 76,
+      statements: 76,
     },
   },
 })


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix "missing act" warnings when calling `render(ui, {container, hydrate})` using `react@alpha`.

**Why**:

Previous `hydrateRoot` usage was just wrong (see https://github.com/facebook/react/issues/22643 for more information).

**How**:

Call `hydrateRoot` with the given `ui` and wrapped in `act`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
