### PR TITLE
feat: Enable "missing act" warnings in React 18 by default

### DIFF
--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -32,7 +32,7 @@ function getGlobalThis() {
   throw new Error('unable to locate global object')
 }
 
-function setReactActEnvironment(isReactActEnvironment) {
+function setIsReactActEnvironment(isReactActEnvironment) {
   getGlobalThis().IS_REACT_ACT_ENVIRONMENT = isReactActEnvironment
 }
 
@@ -43,7 +43,7 @@ function getIsReactActEnvironment() {
 function withGlobalActEnvironment(actImplementation) {
   return callback => {
     const previousActEnvironment = getIsReactActEnvironment()
-    setReactActEnvironment(true)
+    setIsReactActEnvironment(true)
     try {
       // The return value of `act` is always a thenable.
       let callbackNeedsToBeAwaited = false
@@ -64,24 +64,24 @@ function withGlobalActEnvironment(actImplementation) {
           then: (resolve, reject) => {
             thenable.then(
               returnValue => {
-                setReactActEnvironment(previousActEnvironment)
+                setIsReactActEnvironment(previousActEnvironment)
                 resolve(returnValue)
               },
               error => {
-                setReactActEnvironment(previousActEnvironment)
+                setIsReactActEnvironment(previousActEnvironment)
                 reject(error)
               },
             )
           },
         }
       } else {
-        setReactActEnvironment(previousActEnvironment)
+        setIsReactActEnvironment(previousActEnvironment)
         return actResult
       }
     } catch (error) {
       // Can't be a `finally {}` block since we don't know if we have to immediately restore IS_REACT_ACT_ENVIRONMENT
       // or if we have to await the callback first.
-      setReactActEnvironment(previousActEnvironment)
+      setIsReactActEnvironment(previousActEnvironment)
       throw error
     }
   }
@@ -203,6 +203,10 @@ function asyncAct(cb) {
 }
 
 export default act
-export {asyncAct, setReactActEnvironment, getIsReactActEnvironment}
+export {
+  asyncAct,
+  setIsReactActEnvironment as setReactActEnvironment,
+  getIsReactActEnvironment,
+}
 
 /* eslint no-console:0 */

--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,10 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
     })
   }
 
-  // This matches the behavior of React < 18.
+  // No test setup with other test runners available
+  /* istanbul ignore else */
   if (typeof beforeAll === 'function' && typeof afterAll === 'function') {
+    // This matches the behavior of React < 18.
     let previousIsReactActEnvironment = getIsReactActEnvironment()
     beforeAll(() => {
       previousIsReactActEnvironment = getIsReactActEnvironment()

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import {getIsReactActEnvironment, setReactActEnvironment} from './act-compat'
 import {cleanup} from './pure'
 
 // if we're running in a test runner that supports afterEach
@@ -18,6 +19,19 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
     // eslint-disable-next-line no-undef
     teardown(() => {
       cleanup()
+    })
+  }
+
+  // This matches the behavior of React < 18.
+  if (typeof beforeAll === 'function' && typeof afterAll === 'function') {
+    let previousIsReactActEnvironment = getIsReactActEnvironment()
+    beforeAll(() => {
+      previousIsReactActEnvironment = getIsReactActEnvironment()
+      setReactActEnvironment(true)
+    })
+
+    afterAll(() => {
+      setReactActEnvironment(previousIsReactActEnvironment)
     })
   }
 }

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,9 +1,1 @@
 import '@testing-library/jest-dom/extend-expect'
-
-beforeEach(() => {
-  global.IS_REACT_ACT_ENVIRONMENT = true
-})
-
-afterEach(() => {
-  global.IS_REACT_ACT_ENVIRONMENT = false
-})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Enables "missing act" warnings in React 18 for test runners that implement `beforeAll` and `afterAll` (e.g. Jest).
This can be disabled the same way auto-cleanup can be disabled.

**Why**:

Ensures same behavior regarding missing act warnings across as React 16 and 17

**How**:

Set [`IS_REACT_ACT_ENVIRONMENT`](https://github.com/reactwg/react-18/discussions/102) to true once before tests start.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) Will wait until React docs for IS_REACT_ACT_ENVIRONMENT are available.
- [x] Tests
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
