### PR TITLE
fix: Add `@types/react-dom` as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^8.0.0"
+    "@testing-library/dom": "^8.0.0",
+    "@types/react-dom": "^17.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",
-    "@types/react-dom": "^17.0.0",
     "dotenv-cli": "^4.0.0",
     "kcd-scripts": "^11.1.0",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@testing-library/dom": "^8.0.0",
-    "@types/react-dom": "^17.0.0"
+    "@types/react-dom": "*"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",


### PR DESCRIPTION
`@types/react-dom` is used in `types/index.d.ts`, which is an external interface, and thus needs to be declared as a regular rather than a dev dependency so that it is picked up by users of `@testing-library/react`.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This fixes #1000.

**Why**:

`@types/react-dom` is used in `types/index.d.ts`, which is an external interface, and thus needs to be declared as a regular rather than a dev dependency so that it is picked up by users of `@testing-library/react`.

**How**:

Declare `@types/react-dom` as a regular rather than a dev dependency.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] Tests N/A
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
