### PR TITLE
chore: Drop usage of isomorphic act

### DIFF
--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -2,7 +2,6 @@ import * as React from 'react'
 import ReactDOM from 'react-dom'
 import * as testUtils from 'react-dom/test-utils'
 
-const isomorphicAct = React.unstable_act
 const domAct = testUtils.act
 const actSupported = domAct !== undefined
 
@@ -87,7 +86,7 @@ function withGlobalActEnvironment(actImplementation) {
   }
 }
 
-const act = withGlobalActEnvironment(isomorphicAct || domAct || actPolyfill)
+const act = withGlobalActEnvironment(domAct || actPolyfill)
 
 let youHaveBeenWarned = false
 let isAsyncActSupported = null


### PR DESCRIPTION
Failures are fixed with https://github.com/testing-library/react-testing-library/pull/1018

**What**:

Only use documented testing APIs

**Why**:

There's no explicit mention of "isomorphic act" landing with React 18 so let's just drop it's usage (`react-dom/test-utils` uses it anyway). Removing its usage simplifies code while also using less React internals.

**How**:

Drop usage of `React.unstable_act`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- ~[ ]~ Tests
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
