### PR TITLE
chore: Fix failing codesandbox/ci

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
-  "node": "12"
+  "node": "16"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,5 @@
 {
+  "install": "install --force --no-lockfile",
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
   "node": "12"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "npm install --force --no-lockfile",
+  "installCommand": "install --force --no-lockfile",
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
   "node": "12"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "install": "install --force --no-lockfile",
+  "installCommand": "npm install --force --no-lockfile",
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
   "node": "12"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "install --force --no-lockfile",
+  "installCommand": "install:csb",
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
   "node": "12"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,4 @@
 {
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
-  "install": "npm install",
-  "node": "16"
+  "node": "12"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,5 @@
 {
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
+  "install": "npm install",
   "node": "16"
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:bundle:pure": "dotenv -e .bundle.main.env -e .bundle.pure.env kcd-scripts build -- --bundle --no-clean",
     "build:main": "kcd-scripts build --no-clean",
     "format": "kcd-scripts format",
+    "install:csb": "npm install",
     "lint": "kcd-scripts lint",
     "setup": "npm install && npm run validate -s",
     "test": "kcd-scripts test",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@types/react-dom": "^17.0.0",
     "dotenv-cli": "^4.0.0",
-    "kcd-scripts": "^11.1.0",
+    "kcd-scripts": "^11.2.2",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@types/react-dom": "^17.0.0",
     "dotenv-cli": "^4.0.0",
-    "kcd-scripts": "^11.2.2",
+    "kcd-scripts": "^11.1.0",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
Unclear why codesandbox/ci is failing. Clean clone does not fail `npm run build` on node 12 or node 14.

But forcing `npm` instead of `yarn` seems to work so 🤷🏻‍♂️ 