### PR TITLE
chore: Fix failing codesandbox/ci

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "install:csb",
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
   "node": "12"
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:bundle:pure": "dotenv -e .bundle.main.env -e .bundle.pure.env kcd-scripts build -- --bundle --no-clean",
     "build:main": "kcd-scripts build --no-clean",
     "format": "kcd-scripts format",
+    "install:csb": "npm install",
     "lint": "kcd-scripts lint",
     "setup": "npm install && npm run validate -s",
     "test": "kcd-scripts test",


### PR DESCRIPTION
Cherry-picking https://github.com/testing-library/react-testing-library/pull/1020 into `main`