### PR TITLE
fix: Specify a non-* version for @types/react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@testing-library/dom": "^8.5.0",
-    "@types/react-dom": "*"
+    "@types/react-dom": "^18.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: fixes https://github.com/testing-library/react-testing-library/issues/1039

<!-- Why are these changes necessary? -->

**Why**: Updating to react@18 (including types) is broken when using `yarn` because it picks the wrong version

<!-- How were these changes implemented? -->

**How**: Testing

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] N/A - Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] N/A - Tests
- [ ] N/A - TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
