### PR TITLE
fix: Only supports React < 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@testing-library/dom": "^8.0.0",
-    "@types/react-dom": "*"
+    "@types/react-dom": "<18.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",
@@ -60,8 +60,8 @@
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-dom": "*"
+    "react": "<18.0.0",
+    "react-dom": "<18.0.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
Targets 12.x

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Ensure no unsupported dependencies are installed

**Why**:

12.x does not support React 18

**How**:

- Constrain `@types/react` dependency to < 18
- Constraint `react` and `react-dom` peer dependency to < 18
 
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
