### PR TITLE
test(types): Don't assume implicit children

### DIFF
--- a/types/test.tsx
+++ b/types/test.tsx
@@ -129,7 +129,7 @@ export function wrappedRenderC(
   options?: pure.RenderOptions,
 ) {
   interface AppWrapperProps {
-    children?: React.ReactNode;
+    children?: React.ReactNode
     userProviderProps?: {user: string}
   }
   const AppWrapperProps: React.FunctionComponent<AppWrapperProps> = ({

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -129,6 +129,7 @@ export function wrappedRenderC(
   options?: pure.RenderOptions,
 ) {
   interface AppWrapperProps {
+    children?: React.ReactNode;
     userProviderProps?: {user: string}
   }
   const AppWrapperProps: React.FunctionComponent<AppWrapperProps> = ({


### PR DESCRIPTION
Implicit children got removed in React 18 types (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210)