### PR TITLE
chore: Run release from 12.x branch

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,9 @@ name: validate
 on:
   push:
     branches:
-      - '+([0-9])?(.{+([0-9]),x}).x'
+      # Match SemVer major release branches
+      # e.g. "12.x" or "8.x"
+      - '[0-9]+.x'
       - 'main'
       - 'next'
       - 'next-major'
@@ -58,8 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     if:
       ${{ github.repository == 'testing-library/react-testing-library' &&
-      contains('refs/heads/main,refs/heads/beta,refs/heads/next,refs/heads/alpha',
-      github.ref) && github.event_name == 'push' }}
+      github.event_name == 'push' }}
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0


### PR DESCRIPTION
Recent 12.x merge did not run GitHub actions. 

I'm not following the current pattern for release branches so I just simplified it following the [Filter pattern cheat sheet](https://docs.github.com/en/github-ae@latest/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet).

Comfirmed to work in https://github.com/eps1lon/react-testing-library/actions/runs/2150862258

dom-testing-library has the same pattern and we probably need to port that fix over there to prevent it spreading.