### PR TITLE
feat: Export RenderHookOptions type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -120,7 +120,7 @@ export interface RenderHookResult<Result, Props> {
   unmount: () => void
 }
 
-interface RenderHookOptions<Props> {
+export interface RenderHookOptions<Props> {
   /**
    * The argument passed to the renderHook callback. Can be useful if you plan
    * to use the rerender utility to change the values passed to your hook.


### PR DESCRIPTION
Hi - `@testing-library/react-hooks` exported the type `RenderHookOptions`, it would be great if it could be exported here as well since it is helpful when we write wrappers around `renderHook` (e.g. I have a wrapper to enable react-router).

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Export `RenderHookOptions`

**Why**:

It's helpful when writing own extensions to `renderHook`.

**How**:

added an export ;)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [x] Tests N/A
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
