### PR TITLE
feat: Use `globalThis` if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
+    "globals": {
+      "globalThis": "readonly"
+    },
     "rules": {
       "react/prop-types": "off",
       "react/no-adjacent-inline-elements": "off",

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -4,6 +4,10 @@ const domAct = testUtils.act
 
 function getGlobalThis() {
   /* istanbul ignore else */
+  if (typeof globalThis !== 'undefined') {
+    return globalThis
+  }
+  /* istanbul ignore next */
   if (typeof self !== 'undefined') {
     return self
   }


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Closes https://github.com/testing-library/react-testing-library/issues/1061

<!-- Why are these changes necessary? -->

**Why**:

Test runners like `vitest` create environments where `window` does not reflect `self`. This is not an environment that exists outside of `vitest`. This was fixed in latest versions of `vitest` (see https://github.com/vitest-dev/vitest/pull/1256).

But it's good to get in anyway to support older versions as well as other test environments that aren't configured properly but run in later versions of Node or browsers.

**How**:

Use `globalThis` if available.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
