### PR TITLE
chore: Run with latest Node 16 again

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: relax `'16.9.1'` to `16` once GitHub has 16.9.1 cached. 16.9.0 is broken due to https://github.com/nodejs/node/issues/40030
-        node: [12, 14, '16.9.1']
+        node: [12, 14, 16]
         react: [latest, next, experimental]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
https://github.com/nodejs/node/issues/40030 is fixed so we can run on latest Node versions again.