### PR TITLE
fix: Run render queries in the render container only

### DIFF
--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -59,6 +59,13 @@ test('returns baseElement which defaults to document.body', () => {
   expect(baseElement).toBe(document.body)
 })
 
+test('runs queries only on its container', () => {
+  render(<p>Hello</p>)
+  const {getByText, queryByText} = render(<p>Goodbye</p>)
+  expect(queryByText('Hello')).not.toBeInTheDocument() // eslint-disable-line testing-library/prefer-screen-queries
+  expect(getByText('Goodbye')).toBeInTheDocument() // eslint-disable-line testing-library/prefer-screen-queries
+})
+
 test('supports fragments', () => {
   class Test extends React.Component {
     render() {

--- a/src/pure.js
+++ b/src/pure.js
@@ -149,7 +149,7 @@ function renderRoot(
         return template.content
       }
     },
-    ...getQueriesForElement(baseElement, queries),
+    ...getQueriesForElement(container, queries),
   }
 }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: This is a bugfix (as far as I can tell).

**Why**: `render()` by default appends a new `container` to a `baseElement` which is, by default, the global variable `document.body`. This `container` ends up containing the resulting markup for the system under test. However, when using the query methods on the `RenderResult` object, the whole `document` is scanned for matches, not just the markup resulting from the `render()` call. This breaks assumptions about the scope in which queries a run : one would expect the `getByText` and other queries to be scoped to that particular render.

As a matter of fact, this is what happens when the `container` parameter is given explicitly and `baseElement` takes it value, however this is not what happens otherwise. The default behaviour (global querying on all renders) is redundant with what `screen` from `@testing-library/dom` does, without being very clear about it being global.

<!-- How were these changes implemented? -->

**How**:
+ a test reproducing the issue
+ a lot of code reading to eventually just change a single function call parameter =)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) ([pull request](https://github.com/testing-library/react-testing-library/pull/1097))
- [x] Tests
- [x] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
