### PR TITLE
fix: Prevent "missing act" warning for queued microtasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
       "testing-library/no-debugging-utils": "off",
       "testing-library/no-dom-import": "off",
       "testing-library/no-unnecessary-act": "off",
+      "testing-library/prefer-explicit-assert": "off",
+      "testing-library/prefer-find-by": "off",
       "testing-library/prefer-user-event": "off"
     }
   },

--- a/src/__tests__/end-to-end.js
+++ b/src/__tests__/end-to-end.js
@@ -1,73 +1,150 @@
 import * as React from 'react'
 import {render, waitForElementToBeRemoved, screen, waitFor} from '../'
 
-const fetchAMessage = () =>
-  new Promise(resolve => {
-    // we are using random timeout here to simulate a real-time example
-    // of an async operation calling a callback at a non-deterministic time
-    const randomTimeout = Math.floor(Math.random() * 100)
-    setTimeout(() => {
-      resolve({returnedMessage: 'Hello World'})
-    }, randomTimeout)
-  })
-
-function ComponentWithLoader() {
-  const [state, setState] = React.useState({data: undefined, loading: true})
-  React.useEffect(() => {
-    let cancelled = false
-    fetchAMessage().then(data => {
-      if (!cancelled) {
-        setState({data, loading: false})
-      }
+describe.each([
+  ['real timers', () => jest.useRealTimers()],
+  ['fake legacy timers', () => jest.useFakeTimers('legacy')],
+  ['fake modern timers', () => jest.useFakeTimers('modern')],
+])(
+  'it waits for the data to be loaded in a macrotask using %s',
+  (label, useTimers) => {
+    beforeEach(() => {
+      useTimers()
     })
 
-    return () => {
-      cancelled = true
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    const fetchAMessageInAMacrotask = () =>
+      new Promise(resolve => {
+        // we are using random timeout here to simulate a real-time example
+        // of an async operation calling a callback at a non-deterministic time
+        const randomTimeout = Math.floor(Math.random() * 100)
+        setTimeout(() => {
+          resolve({returnedMessage: 'Hello World'})
+        }, randomTimeout)
+      })
+
+    function ComponentWithMacrotaskLoader() {
+      const [state, setState] = React.useState({data: undefined, loading: true})
+      React.useEffect(() => {
+        let cancelled = false
+        fetchAMessageInAMacrotask().then(data => {
+          if (!cancelled) {
+            setState({data, loading: false})
+          }
+        })
+
+        return () => {
+          cancelled = true
+        }
+      }, [])
+
+      if (state.loading) {
+        return <div>Loading...</div>
+      }
+
+      return (
+        <div data-testid="message">
+          Loaded this message: {state.data.returnedMessage}!
+        </div>
+      )
     }
-  }, [])
 
-  if (state.loading) {
-    return <div>Loading...</div>
-  }
+    test('waitForElementToBeRemoved', async () => {
+      render(<ComponentWithMacrotaskLoader />)
+      const loading = () => screen.getByText('Loading...')
+      await waitForElementToBeRemoved(loading)
+      expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
+    })
 
-  return (
-    <div data-testid="message">
-      Loaded this message: {state.data.returnedMessage}!
-    </div>
-  )
-}
+    test('waitFor', async () => {
+      render(<ComponentWithMacrotaskLoader />)
+      // eslint-disable-next-line testing-library/prefer-find-by -- Sir, this is a test.
+      await waitFor(() => screen.getByText(/Loading../))
+      // eslint-disable-next-line testing-library/prefer-find-by -- Sir, this is a test.
+      await waitFor(() => screen.getByText(/Loaded this message:/))
+      expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
+    })
+
+    test('findBy', async () => {
+      render(<ComponentWithMacrotaskLoader />)
+      await expect(screen.findByTestId('message')).resolves.toHaveTextContent(
+        /Hello World/,
+      )
+    })
+  },
+)
 
 describe.each([
   ['real timers', () => jest.useRealTimers()],
   ['fake legacy timers', () => jest.useFakeTimers('legacy')],
   ['fake modern timers', () => jest.useFakeTimers('modern')],
-])('it waits for the data to be loaded using %s', (label, useTimers) => {
-  beforeEach(() => {
-    useTimers()
-  })
+])(
+  'it waits for the data to be loaded in a microtask using %s',
+  (label, useTimers) => {
+    beforeEach(() => {
+      useTimers()
+    })
 
-  afterEach(() => {
-    jest.useRealTimers()
-  })
+    afterEach(() => {
+      jest.useRealTimers()
+    })
 
-  test('waitForElementToBeRemoved', async () => {
-    render(<ComponentWithLoader />)
-    const loading = () => screen.getByText('Loading...')
-    await waitForElementToBeRemoved(loading)
-    expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
-  })
+    const fetchAMessageInAMicrotask = () =>
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve({title: 'Hello World'}),
+      })
 
-  test('waitFor', async () => {
-    render(<ComponentWithLoader />)
-    const message = () => screen.getByText(/Loaded this message:/)
-    await waitFor(message)
-    expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
-  })
+    function ComponentWithMicrotaskLoader() {
+      const [fetchState, setFetchState] = React.useState({fetching: true})
 
-  test('findBy', async () => {
-    render(<ComponentWithLoader />)
-    await expect(screen.findByTestId('message')).resolves.toHaveTextContent(
-      /Hello World/,
-    )
-  })
-})
+      React.useEffect(() => {
+        if (fetchState.fetching) {
+          fetchAMessageInAMicrotask().then(res => {
+            return res.json().then(data => {
+              setFetchState({todo: data.title, fetching: false})
+            })
+          })
+        }
+      }, [fetchState])
+
+      if (fetchState.fetching) {
+        return <p>Loading..</p>
+      }
+
+      return (
+        <div data-testid="message">Loaded this message: {fetchState.todo}</div>
+      )
+    }
+
+    test('waitForElementToBeRemoved', async () => {
+      render(<ComponentWithMicrotaskLoader />)
+      const loading = () => screen.getByText('Loading..')
+      await waitForElementToBeRemoved(loading)
+      expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
+    })
+
+    test('waitFor', async () => {
+      render(<ComponentWithMicrotaskLoader />)
+      await waitFor(() => {
+        // eslint-disable-next-line testing-library/prefer-explicit-assert -- Sir, this is a test.
+        screen.getByText('Loading..')
+      })
+      await waitFor(() => {
+        // eslint-disable-next-line testing-library/prefer-explicit-assert -- Sir, this is a test.
+        screen.getByText(/Loaded this message:/)
+      })
+      expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
+    })
+
+    test('findBy', async () => {
+      render(<ComponentWithMicrotaskLoader />)
+      await expect(screen.findByTestId('message')).resolves.toHaveTextContent(
+        /Hello World/,
+      )
+    })
+  },
+)

--- a/src/__tests__/end-to-end.js
+++ b/src/__tests__/end-to-end.js
@@ -61,9 +61,7 @@ describe.each([
 
     test('waitFor', async () => {
       render(<ComponentWithMacrotaskLoader />)
-      // eslint-disable-next-line testing-library/prefer-find-by -- Sir, this is a test.
       await waitFor(() => screen.getByText(/Loading../))
-      // eslint-disable-next-line testing-library/prefer-find-by -- Sir, this is a test.
       await waitFor(() => screen.getByText(/Loaded this message:/))
       expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
     })
@@ -130,11 +128,9 @@ describe.each([
     test('waitFor', async () => {
       render(<ComponentWithMicrotaskLoader />)
       await waitFor(() => {
-        // eslint-disable-next-line testing-library/prefer-explicit-assert -- Sir, this is a test.
         screen.getByText('Loading..')
       })
       await waitFor(() => {
-        // eslint-disable-next-line testing-library/prefer-explicit-assert -- Sir, this is a test.
         screen.getByText(/Loaded this message:/)
       })
       expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)

--- a/src/__tests__/end-to-end.js
+++ b/src/__tests__/end-to-end.js
@@ -102,9 +102,27 @@ describe.each([
       React.useEffect(() => {
         if (fetchState.fetching) {
           fetchAMessageInAMicrotask().then(res => {
-            return res.json().then(data => {
-              setFetchState({todo: data.title, fetching: false})
-            })
+            return (
+              res
+                .json()
+                // By spec, the runtime can only yield back to the event loop once
+                // the microtask queue is empty.
+                // So we ensure that we actually wait for that as well before yielding back from `waitFor`.
+                .then(data => data)
+                .then(data => data)
+                .then(data => data)
+                .then(data => data)
+                .then(data => data)
+                .then(data => data)
+                .then(data => data)
+                .then(data => data)
+                .then(data => data)
+                .then(data => data)
+                .then(data => data)
+                .then(data => {
+                  setFetchState({todo: data.title, fetching: false})
+                })
+            )
           })
         }
       }, [fetchState])

--- a/src/pure.js
+++ b/src/pure.js
@@ -12,6 +12,19 @@ import act, {
 } from './act-compat'
 import {fireEvent} from './fire-event'
 
+function jestFakeTimersAreEnabled() {
+  /* istanbul ignore else */
+  if (typeof jest !== 'undefined' && jest !== null) {
+    return (
+      // legacy timers
+      setTimeout._isMockFunction === true || // modern timers
+      Object.prototype.hasOwnProperty.call(setTimeout, 'clock')
+    )
+  } // istanbul ignore next
+
+  return false
+}
+
 configureDTL({
   unstable_advanceTimersWrapper: cb => {
     return act(cb)
@@ -23,7 +36,21 @@ configureDTL({
     const previousActEnvironment = getIsReactActEnvironment()
     setReactActEnvironment(false)
     try {
-      return await cb()
+      const result = await cb()
+      // Drain microtask queue.
+      // Otherwise we'll restore the previous act() environment, before we resolve the `waitFor` call.
+      // The caller would have no chance to wrap the in-flight Promises in `act()`
+      await new Promise(resolve => {
+        setTimeout(() => {
+          resolve()
+        }, 0)
+
+        if (jestFakeTimersAreEnabled()) {
+          jest.advanceTimersByTime(0)
+        }
+      })
+
+      return result
     } finally {
       setReactActEnvironment(previousActEnvironment)
     }

--- a/src/pure.js
+++ b/src/pure.js
@@ -12,19 +12,6 @@ import act, {
 } from './act-compat'
 import {fireEvent} from './fire-event'
 
-function jestFakeTimersAreEnabled() {
-  /* istanbul ignore else */
-  if (typeof jest !== 'undefined' && jest !== null) {
-    return (
-      // legacy timers
-      setTimeout._isMockFunction === true || // modern timers
-      Object.prototype.hasOwnProperty.call(setTimeout, 'clock')
-    )
-  } // istanbul ignore next
-
-  return false
-}
-
 configureDTL({
   unstable_advanceTimersWrapper: cb => {
     return act(cb)
@@ -40,15 +27,7 @@ configureDTL({
       // Drain microtask queue.
       // Otherwise we'll restore the previous act() environment, before we resolve the `waitFor` call.
       // The caller would have no chance to wrap the in-flight Promises in `act()`
-      await new Promise(resolve => {
-        setTimeout(() => {
-          resolve()
-        }, 0)
-
-        if (jestFakeTimersAreEnabled()) {
-          jest.advanceTimersByTime(0)
-        }
-      })
+      await Promise.resolve().then(() => {})
 
       return result
     } finally {

--- a/src/pure.js
+++ b/src/pure.js
@@ -12,6 +12,20 @@ import act, {
 } from './act-compat'
 import {fireEvent} from './fire-event'
 
+function jestFakeTimersAreEnabled() {
+  /* istanbul ignore else */
+  if (typeof jest !== 'undefined' && jest !== null) {
+    return (
+      // legacy timers
+      setTimeout._isMockFunction === true || // modern timers
+      // eslint-disable-next-line prefer-object-has-own -- No Object.hasOwn in all target environments we support.
+      Object.prototype.hasOwnProperty.call(setTimeout, 'clock')
+    )
+  } // istanbul ignore next
+
+  return false
+}
+
 configureDTL({
   unstable_advanceTimersWrapper: cb => {
     return act(cb)
@@ -27,7 +41,15 @@ configureDTL({
       // Drain microtask queue.
       // Otherwise we'll restore the previous act() environment, before we resolve the `waitFor` call.
       // The caller would have no chance to wrap the in-flight Promises in `act()`
-      await Promise.resolve().then(() => {})
+      await new Promise(resolve => {
+        setTimeout(() => {
+          resolve()
+        }, 0)
+
+        if (jestFakeTimersAreEnabled()) {
+          jest.advanceTimersByTime(0)
+        }
+      })
 
       return result
     } finally {


### PR DESCRIPTION
**What**:

Closes https://github.com/testing-library/react-testing-library/issues/1125
Closes https://github.com/testing-library/react-testing-library/issues/1051

**Why**:

Once the `callback` passed to `waitFor` resolves, there could be other microtasks scheduled.
If we now yield back from `waitFor` we restore the `REACT_IS_ACT_ENVIRONMENT`. However, the tester `await`s the `waitFor` and before the runtime yields back to the event loop, it needs (by spec) to drain the scheduled microtasks. This may include state updates which now run without `REACT_IS_ACT_ENVIRONMENT` which triggers warning.

**How**:

Drain microtask queue before resolving `waitFor` call.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- ~[ ]~ TypeScript definitions updated
- [x] Explainer
- [x] Test in issue repro: https://github.com/trv-wcaneira/act-warning-mcve/pull/1
- [x] Test in issue repro: https://github.com/eps1lon/missing-act-setstate-finally-repro/pull/1
- ~[ ] Test with React 17~ We no longer support React 17
- [x] Test on mui/material-ui: https://github.com/mui/material-ui/pull/36221
- [x] Test in Klarna monorepo
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
