### PR TITLE
test: Add Node.js 18.x to test matrix

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
         react: [latest, next, experimental]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Keeping Node.js 12.x since the current release supports it. I see no reason to drop support yet.