### PR TITLE
fix: Pass initialProps to wrapper component

### DIFF
--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -80,6 +80,29 @@ test('passes initialProps to a wrapper component', async () => {
   expect(result.current).toEqual('provided')
 })
 
+test('rerenders wrapper with given props', async () => {
+  const Context = React.createContext('default')
+  function Wrapper({value, children}) {
+    return <Context.Provider value={value}>{children}</Context.Provider>
+  }
+  const initialProps = {value: 'initial'}
+  const {result, rerender} = renderHook(
+    () => {
+      return React.useContext(Context)
+    },
+    {
+      wrapper: Wrapper,
+      initialProps,
+    },
+  )
+
+  expect(result.current).toEqual('initial')
+
+  rerender({value: 'updated'})
+
+  expect(result.current).toEqual('updated')
+})
+
 test('legacyRoot uses legacy ReactDOM.render', () => {
   jest.spyOn(console, 'error').mockImplementation(() => {})
 

--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -61,6 +61,25 @@ test('allows wrapper components', async () => {
   expect(result.current).toEqual('provided')
 })
 
+test('passes initialProps to a wrapper component', async () => {
+  const Context = React.createContext('default')
+  function Wrapper({value, children}) {
+    return <Context.Provider value={value}>{children}</Context.Provider>
+  }
+  const initialProps = {value: 'provided'}
+  const {result} = renderHook(
+    () => {
+      return React.useContext(Context)
+    },
+    {
+      wrapper: Wrapper,
+      initialProps,
+    },
+  )
+
+  expect(result.current).toEqual('provided')
+})
+
 test('legacyRoot uses legacy ReactDOM.render', () => {
   jest.spyOn(console, 'error').mockImplementation(() => {})
 

--- a/src/pure.js
+++ b/src/pure.js
@@ -219,7 +219,7 @@ function cleanup() {
 }
 
 function renderHook(renderCallback, options = {}) {
-  const {initialProps, ...renderOptions} = options
+  const {initialProps, wrapper: WrapperComponent, ...renderOptions} = options
   const result = React.createRef()
 
   function TestComponent({renderCallbackProps}) {
@@ -232,10 +232,14 @@ function renderHook(renderCallback, options = {}) {
     return null
   }
 
-  const {rerender: baseRerender, unmount} = render(
-    <TestComponent renderCallbackProps={initialProps} />,
-    renderOptions,
-  )
+  let component = <TestComponent renderCallbackProps={initialProps} />
+
+  if (WrapperComponent) {
+    component = (
+      <WrapperComponent {...initialProps}>{component}</WrapperComponent>
+    )
+  }
+  const {rerender: baseRerender, unmount} = render(component, renderOptions)
 
   function rerender(rerenderCallbackProps) {
     return baseRerender(

--- a/src/pure.js
+++ b/src/pure.js
@@ -232,18 +232,25 @@ function renderHook(renderCallback, options = {}) {
     return null
   }
 
-  let component = <TestComponent renderCallbackProps={initialProps} />
-
-  if (WrapperComponent) {
-    component = (
-      <WrapperComponent {...initialProps}>{component}</WrapperComponent>
+  const wrapUiIfNeeded = (innerElement, props) =>
+    WrapperComponent ? (
+      <WrapperComponent {...props}>{innerElement}</WrapperComponent>
+    ) : (
+      innerElement
     )
-  }
+
+  const component = wrapUiIfNeeded(
+    <TestComponent renderCallbackProps={initialProps} />,
+    initialProps,
+  )
   const {rerender: baseRerender, unmount} = render(component, renderOptions)
 
   function rerender(rerenderCallbackProps) {
     return baseRerender(
-      <TestComponent renderCallbackProps={rerenderCallbackProps} />,
+      wrapUiIfNeeded(
+        <TestComponent renderCallbackProps={rerenderCallbackProps} />,
+        rerenderCallbackProps,
+      ),
     )
   }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This PR enables passing initialProps to wrapper component, as react-hooks-testing-library does. See testing-library/testing-library-docs#1161.
<!-- Why are these changes necessary? -->

**Why**:
To test hooks which interact with context. 
For testing that, the easiest way is to create wrapper `(val) => <context.Provider value={val}` and test by changing the value of wrapper props.
<!-- How were these changes implemented? -->

**How**:
Changed renderHook logic to render wrapper component if wrapper is provided, and pass initialProps there.
Alternatively, we can do the same thing by changing `renderRoot`, but it is a bit complex (See diff in https://github.com/no-yan/react-testing-library/commit/730fe50de69197939a8b8b3ac6b82abb82818e11) and I don't think it solves the undermentioned problem.


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
~~- [ ]~~ TypeScript definitions updated
- [ ] Ready to be merged N/A
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
**Note**

For compatibility with react hooks testing library([code](https://github.com/testing-library/react-hooks-testing-library/blob/121344370b2285dc3d5166a16ead71186bfe85d8/src/helpers/createTestHarness.tsx#L30-L33), [doc](https://react-hooks-testing-library.com/usage/advanced-hooks#context:~:text=Note%20the%20initialProps%20and%20the%20new%20props%20of%20rerender%20are%20also%20accessed%20by%20the%20callback%20function%20of%20the%20renderHook%20which%20the%20wrapper%20is%20provided%20to.)), I intentionally pass props to both the wrapper component and the Test Component.
I don't think there is any rationale for this specification in itself, but given that the React Testing Library is essential for React 18 migration, I think we should try to make the migration as easy as React. Therefore I implemented in a way similar to React hooks testing library.

However, this specification itself has its own limitation and will need to be changed in the future, as it does not allow to test hooks that use both props and context, like:


```
const {result} = renderHook((price) => {
    const taxRate = useContext(TaxRate)

    return price * taxRate
  })
```