### PR TITLE
feat: Drop support for Node.js 12.x

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "installCommand": "install:csb",
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
-  "node": "12"
+  "node": "14"
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
         react: [latest, next, experimental]
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "types/index.d.ts",
   "module": "dist/@testing-library/react.esm.js",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
BREAKING CHANGE: Minimum supported Node.js version is now 14.x

**What**:

Drop support for Node.js 12.x

**Why**:

Reached EOL in April 2022. Tooling is starting to drop Node.js 12.x (see JSDOM) as well so it's time to upgrade to be able to test compat with latest test frameworks (e.g. Jest).

**How**:

Targetting alpha for now. Want to batch this with https://github.com/testing-library/dom-testing-library/issues/1202
Same as https://github.com/testing-library/dom-testing-library/pull/1207

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
