### PR TITLE
chore: rename `next` channel to `canary`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [14, 16, 18]
-        react: [latest, next, experimental, canary]
+        react: [latest, canary, experimental]
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [14, 16, 18]
-        react: [latest, next, experimental]
+        react: [latest, next, experimental, canary]
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo


### PR DESCRIPTION
**What**:

Following the [react announcement of canary version](https://react.dev/blog/2023/05/03/react-canaries), I believe we should test on the `canary` channel and since it's just a rename, I believe removing the `next` channel is fine.

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~~Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~~
- [ ] ~~Tests~~
- [ ] ~~TypeScript definitions updated~~
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
