### PR TITLE
fix: Require `await act(...)`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,14 +6,14 @@ module.exports = Object.assign(jestConfig, {
     // Full coverage across the build matrix (React 18, 19) but not in a single job
     // Ful coverage is checked via codecov
     './src/act-compat': {
-      branches: 90,
+      branches: 80,
     },
     './src/pure': {
       // minimum coverage of jobs using React 18 and 19
-      branches: 95,
-      functions: 88,
-      lines: 92,
-      statements: 92,
+      branches: 90,
+      functions: 81,
+      lines: 91,
+      statements: 91,
     },
   },
 })

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
       "react/no-adjacent-inline-elements": "off",
       "import/no-unassigned-import": "off",
       "import/named": "off",
+      "testing-library/no-await-sync-events": "off",
       "testing-library/no-container": "off",
       "testing-library/no-debugging-utils": "off",
       "testing-library/no-dom-import": "off",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/runtime": "^7.12.5"
   },
   "devDependencies": {
-    "@testing-library/dom": "^10.0.0",
+    "@testing-library/dom": "https://pkg.csb.dev/testing-library/dom-testing-library/commit/8abda5aa/@testing-library/dom",
     "@testing-library/jest-dom": "^5.11.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -63,7 +63,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@testing-library/dom": "^10.0.0",
+    "@testing-library/dom": "^11.0.0",
     "@types/react": "^18.0.0 || ^19.0.0",
     "@types/react-dom": "^18.0.0 || ^19.0.0",
     "react": "^18.0.0 || ^19.0.0",

--- a/src/__tests__/act-compat.js
+++ b/src/__tests__/act-compat.js
@@ -1,0 +1,99 @@
+import * as React from 'react'
+import {render, fireEvent, screen} from '../'
+import {actIfEnabled} from '../act-compat'
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true
+})
+
+test('render calls useEffect immediately', async () => {
+  const effectCb = jest.fn()
+  function MyUselessComponent() {
+    React.useEffect(effectCb)
+    return null
+  }
+  await render(<MyUselessComponent />)
+  expect(effectCb).toHaveBeenCalledTimes(1)
+})
+
+test('findByTestId returns the element', async () => {
+  const ref = React.createRef()
+  await render(<div ref={ref} data-testid="foo" />)
+  expect(await screen.findByTestId('foo')).toBe(ref.current)
+})
+
+test('fireEvent triggers useEffect calls', async () => {
+  const effectCb = jest.fn()
+  function Counter() {
+    React.useEffect(effectCb)
+    const [count, setCount] = React.useState(0)
+    return <button onClick={() => setCount(count + 1)}>{count}</button>
+  }
+  const {
+    container: {firstChild: buttonNode},
+  } = await render(<Counter />)
+
+  effectCb.mockClear()
+  // eslint-disable-next-line testing-library/no-await-sync-events --  TODO: Remove lint rule.
+  await fireEvent.click(buttonNode)
+  expect(buttonNode).toHaveTextContent('1')
+  expect(effectCb).toHaveBeenCalledTimes(1)
+})
+
+test('calls to hydrate will run useEffects', async () => {
+  const effectCb = jest.fn()
+  function MyUselessComponent() {
+    React.useEffect(effectCb)
+    return null
+  }
+  await render(<MyUselessComponent />, {hydrate: true})
+  expect(effectCb).toHaveBeenCalledTimes(1)
+})
+
+test('cleans up IS_REACT_ACT_ENVIRONMENT if its callback throws', async () => {
+  global.IS_REACT_ACT_ENVIRONMENT = false
+
+  await expect(() =>
+    actIfEnabled(() => {
+      throw new Error('threw')
+    }),
+  ).rejects.toThrow('threw')
+
+  expect(global.IS_REACT_ACT_ENVIRONMENT).toEqual(false)
+})
+
+test('cleans up IS_REACT_ACT_ENVIRONMENT if its async callback throws', async () => {
+  global.IS_REACT_ACT_ENVIRONMENT = false
+
+  await expect(() =>
+    actIfEnabled(async () => {
+      throw new Error('thenable threw')
+    }),
+  ).rejects.toThrow('thenable threw')
+
+  expect(global.IS_REACT_ACT_ENVIRONMENT).toEqual(false)
+})
+
+test('state update from microtask does not trigger "missing act" warning', async () => {
+  let triggerStateUpdateFromMicrotask
+  function App() {
+    const [state, setState] = React.useState(0)
+    triggerStateUpdateFromMicrotask = () => setState(1)
+    React.useEffect(() => {
+      // eslint-disable-next-line jest/no-conditional-in-test
+      if (state === 1) {
+        Promise.resolve().then(() => {
+          setState(2)
+        })
+      }
+    }, [state])
+    return state
+  }
+  const {container} = await render(<App />)
+
+  await actIfEnabled(() => {
+    triggerStateUpdateFromMicrotask()
+  })
+
+  expect(container).toHaveTextContent('2')
+})

--- a/src/__tests__/act.js
+++ b/src/__tests__/act.js
@@ -1,69 +1,26 @@
 import * as React from 'react'
-import {act, render, fireEvent, screen} from '../'
+import {act, render} from '../'
 
-test('render calls useEffect immediately', () => {
-  const effectCb = jest.fn()
-  function MyUselessComponent() {
-    React.useEffect(effectCb)
-    return null
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true
+})
+
+test('does not work outside IS_REACT_ENVIRONMENT like React.act', async () => {
+  let setState
+  function Component() {
+    const [state, _setState] = React.useState(0)
+    setState = _setState
+    return state
   }
-  render(<MyUselessComponent />)
-  expect(effectCb).toHaveBeenCalledTimes(1)
-})
+  await render(<Component />)
 
-test('findByTestId returns the element', async () => {
-  const ref = React.createRef()
-  render(<div ref={ref} data-testid="foo" />)
-  expect(await screen.findByTestId('foo')).toBe(ref.current)
-})
-
-test('fireEvent triggers useEffect calls', () => {
-  const effectCb = jest.fn()
-  function Counter() {
-    React.useEffect(effectCb)
-    const [count, setCount] = React.useState(0)
-    return <button onClick={() => setCount(count + 1)}>{count}</button>
-  }
-  const {
-    container: {firstChild: buttonNode},
-  } = render(<Counter />)
-
-  effectCb.mockClear()
-  fireEvent.click(buttonNode)
-  expect(buttonNode).toHaveTextContent('1')
-  expect(effectCb).toHaveBeenCalledTimes(1)
-})
-
-test('calls to hydrate will run useEffects', () => {
-  const effectCb = jest.fn()
-  function MyUselessComponent() {
-    React.useEffect(effectCb)
-    return null
-  }
-  render(<MyUselessComponent />, {hydrate: true})
-  expect(effectCb).toHaveBeenCalledTimes(1)
-})
-
-test('cleans up IS_REACT_ACT_ENVIRONMENT if its callback throws', () => {
   global.IS_REACT_ACT_ENVIRONMENT = false
-
-  expect(() =>
-    act(() => {
-      throw new Error('threw')
-    }),
-  ).toThrow('threw')
-
-  expect(global.IS_REACT_ACT_ENVIRONMENT).toEqual(false)
-})
-
-test('cleans up IS_REACT_ACT_ENVIRONMENT if its async callback throws', async () => {
-  global.IS_REACT_ACT_ENVIRONMENT = false
-
-  await expect(() =>
-    act(async () => {
-      throw new Error('thenable threw')
-    }),
-  ).rejects.toThrow('thenable threw')
-
-  expect(global.IS_REACT_ACT_ENVIRONMENT).toEqual(false)
+  await expect(async () => {
+    await act(() => {
+      setState(1)
+    })
+  }).toErrorDev(
+    'The current testing environment is not configured to support act(...)',
+    {withoutStack: true},
+  )
 })

--- a/src/__tests__/auto-cleanup-skip.js
+++ b/src/__tests__/auto-cleanup-skip.js
@@ -3,14 +3,15 @@ import * as React from 'react'
 let render
 beforeAll(() => {
   process.env.RTL_SKIP_AUTO_CLEANUP = 'true'
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
   const rtl = require('../')
   render = rtl.render
 })
 
 // This one verifies that if RTL_SKIP_AUTO_CLEANUP is set
 // then we DON'T auto-wire up the afterEach for folks
-test('first', () => {
-  render(<div>hi</div>)
+test('first', async () => {
+  await render(<div>hi</div>)
 })
 
 test('second', () => {

--- a/src/__tests__/auto-cleanup.js
+++ b/src/__tests__/auto-cleanup.js
@@ -4,8 +4,8 @@ import {render} from '../'
 // This just verifies that by importing RTL in an
 // environment which supports afterEach (like jest)
 // we'll get automatic cleanup between tests.
-test('first', () => {
-  render(<div>hi</div>)
+test('first', async () => {
+  await render(<div>hi</div>)
 })
 
 test('second', () => {

--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {render, cleanup} from '../'
 
-test('cleans up the document', () => {
+test('cleans up the document', async () => {
   const spy = jest.fn()
   const divId = 'my-div'
 
@@ -16,18 +16,18 @@ test('cleans up the document', () => {
     }
   }
 
-  render(<Test />)
-  cleanup()
+  await render(<Test />)
+  await cleanup()
   expect(document.body).toBeEmptyDOMElement()
   expect(spy).toHaveBeenCalledTimes(1)
 })
 
-test('cleanup does not error when an element is not a child', () => {
-  render(<div />, {container: document.createElement('div')})
-  cleanup()
+test('cleanup does not error when an element is not a child', async () => {
+  await render(<div />, {container: document.createElement('div')})
+  await cleanup()
 })
 
-test('cleanup runs effect cleanup functions', () => {
+test('cleanup runs effect cleanup functions', async () => {
   const spy = jest.fn()
 
   const Test = () => {
@@ -36,9 +36,21 @@ test('cleanup runs effect cleanup functions', () => {
     return null
   }
 
-  render(<Test />)
-  cleanup()
+  await render(<Test />)
+  await cleanup()
   expect(spy).toHaveBeenCalledTimes(1)
+})
+
+test('cleanup cleans up every root and disconnects containers', async () => {
+  const {container: container1} = await render(<div />)
+  const {container: container2} = await render(<span />)
+
+  await cleanup()
+
+  expect(container1).toBeEmptyDOMElement()
+  expect(container1.isConnected).toBe(false)
+  expect(container2).toBeEmptyDOMElement()
+  expect(container2.isConnected).toBe(false)
 })
 
 describe('fake timers and missing act warnings', () => {
@@ -55,7 +67,7 @@ describe('fake timers and missing act warnings', () => {
     jest.useRealTimers()
   })
 
-  test('cleanup does not flush microtasks', () => {
+  test('cleanup does not flush microtasks', async () => {
     const microTaskSpy = jest.fn()
     function Test() {
       const counter = 1
@@ -72,22 +84,27 @@ describe('fake timers and missing act warnings', () => {
 
         return () => {
           cancelled = true
+          Promise.resolve().then(() => {
+            microTaskSpy()
+          })
         }
       }, [counter])
 
       return null
     }
-    render(<Test />)
+    await render(<Test />)
+    expect(microTaskSpy).toHaveBeenCalledTimes(1)
 
-    cleanup()
-
-    expect(microTaskSpy).toHaveBeenCalledTimes(0)
+    const cleanedUp = cleanup()
+    expect(microTaskSpy).toHaveBeenCalledTimes(1)
+    await cleanedUp
+    expect(microTaskSpy).toHaveBeenCalledTimes(2)
     // console.error is mocked
     // eslint-disable-next-line no-console
     expect(console.error).toHaveBeenCalledTimes(0)
   })
 
-  test('cleanup does not swallow missing act warnings', () => {
+  test('cleanup does not swallow missing act warnings', async () => {
     const deferredStateUpdateSpy = jest.fn()
     function Test() {
       const counter = 1
@@ -109,10 +126,10 @@ describe('fake timers and missing act warnings', () => {
 
       return null
     }
-    render(<Test />)
+    await render(<Test />)
 
     jest.runAllTimers()
-    cleanup()
+    await cleanup()
 
     expect(deferredStateUpdateSpy).toHaveBeenCalledTimes(1)
     // console.error is mocked

--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -9,9 +9,9 @@ afterEach(() => {
   console.log.mockRestore()
 })
 
-test('debug pretty prints the container', () => {
+test('debug pretty prints the container', async () => {
   const HelloWorld = () => <h1>Hello World</h1>
-  const {debug} = render(<HelloWorld />)
+  const {debug} = await render(<HelloWorld />)
   debug()
   expect(console.log).toHaveBeenCalledTimes(1)
   expect(console.log).toHaveBeenCalledWith(
@@ -19,14 +19,14 @@ test('debug pretty prints the container', () => {
   )
 })
 
-test('debug pretty prints multiple containers', () => {
+test('debug pretty prints multiple containers', async () => {
   const HelloWorld = () => (
     <>
       <h1 data-testid="testId">Hello World</h1>
       <h1 data-testid="testId">Hello World</h1>
     </>
   )
-  const {debug} = render(<HelloWorld />)
+  const {debug} = await render(<HelloWorld />)
   const multipleElements = screen.getAllByTestId('testId')
   debug(multipleElements)
 
@@ -36,9 +36,9 @@ test('debug pretty prints multiple containers', () => {
   )
 })
 
-test('allows same arguments as prettyDOM', () => {
+test('allows same arguments as prettyDOM', async () => {
   const HelloWorld = () => <h1>Hello World</h1>
-  const {debug, container} = render(<HelloWorld />)
+  const {debug, container} = await render(<HelloWorld />)
   debug(container, 6, {highlight: false})
   expect(console.log).toHaveBeenCalledTimes(1)
   expect(console.log.mock.calls[0]).toMatchInlineSnapshot(`

--- a/src/__tests__/end-to-end.js
+++ b/src/__tests__/end-to-end.js
@@ -1,5 +1,5 @@
-import * as React from 'react'
-import {render, waitForElementToBeRemoved, screen, waitFor} from '../'
+/* eslint-disable jest/no-conditional-in-test, jest/no-if, jest/no-conditional-expect -- different behavior based on React version */
+let React, cleanup, render, screen, waitFor, waitForElementToBeRemoved
 
 describe.each([
   ['real timers', () => jest.useRealTimers()],
@@ -9,10 +9,25 @@ describe.each([
   'it waits for the data to be loaded in a macrotask using %s',
   (label, useTimers) => {
     beforeEach(() => {
+      jest.resetModules()
+      global.IS_REACT_ACT_ENVIRONMENT = true
+      process.env.RTL_SKIP_AUTO_CLEANUP = '0'
+
       useTimers()
+
+      React = require('react')
+      ;({
+        cleanup,
+        render,
+        screen,
+        waitFor,
+        waitForElementToBeRemoved,
+      } = require('..'))
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+      await cleanup()
+      global.IS_REACT_ACT_ENVIRONMENT = false
       jest.useRealTimers()
     })
 
@@ -53,21 +68,21 @@ describe.each([
     }
 
     test('waitForElementToBeRemoved', async () => {
-      render(<ComponentWithMacrotaskLoader />)
+      await render(<ComponentWithMacrotaskLoader />)
       const loading = () => screen.getByText('Loading...')
       await waitForElementToBeRemoved(loading)
       expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
     })
 
     test('waitFor', async () => {
-      render(<ComponentWithMacrotaskLoader />)
+      await render(<ComponentWithMacrotaskLoader />)
       await waitFor(() => screen.getByText(/Loading../))
       await waitFor(() => screen.getByText(/Loaded this message:/))
       expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
     })
 
     test('findBy', async () => {
-      render(<ComponentWithMacrotaskLoader />)
+      await render(<ComponentWithMacrotaskLoader />)
       await expect(screen.findByTestId('message')).resolves.toHaveTextContent(
         /Hello World/,
       )
@@ -83,10 +98,25 @@ describe.each([
   'it waits for the data to be loaded in many microtask using %s',
   (label, useTimers) => {
     beforeEach(() => {
+      jest.resetModules()
+      global.IS_REACT_ACT_ENVIRONMENT = true
+      process.env.RTL_SKIP_AUTO_CLEANUP = '0'
+
       useTimers()
+
+      React = require('react')
+      ;({
+        cleanup,
+        render,
+        screen,
+        waitFor,
+        waitForElementToBeRemoved,
+      } = require('..'))
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+      await cleanup()
+      global.IS_REACT_ACT_ENVIRONMENT = false
       jest.useRealTimers()
     })
 
@@ -137,25 +167,21 @@ describe.each([
     }
 
     test('waitForElementToBeRemoved', async () => {
-      render(<ComponentWithMicrotaskLoader />)
+      await render(<ComponentWithMicrotaskLoader />)
       const loading = () => screen.getByText('Loading..')
-      await waitForElementToBeRemoved(loading)
+      // Already flushed microtasks so we'll never see the loading state in a test.
+      expect(loading).toThrowError(/Unable to find an element with the text/)
       expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
     })
 
-    test('waitFor', async () => {
-      render(<ComponentWithMicrotaskLoader />)
-      await waitFor(() => {
-        screen.getByText('Loading..')
-      })
-      await waitFor(() => {
-        screen.getByText(/Loaded this message:/)
-      })
+    test('waitFor is not needed since microtasks are flushed', async () => {
+      await render(<ComponentWithMicrotaskLoader />)
+
       expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
     })
 
     test('findBy', async () => {
-      render(<ComponentWithMicrotaskLoader />)
+      await render(<ComponentWithMicrotaskLoader />)
       await expect(screen.findByTestId('message')).resolves.toHaveTextContent(
         /Hello World/,
       )
@@ -171,10 +197,25 @@ describe.each([
   'it waits for the data to be loaded in a microtask using %s',
   (label, useTimers) => {
     beforeEach(() => {
+      jest.resetModules()
+      global.IS_REACT_ACT_ENVIRONMENT = true
+      process.env.RTL_SKIP_AUTO_CLEANUP = '0'
+
       useTimers()
+
+      React = require('react')
+      ;({
+        cleanup,
+        render,
+        screen,
+        waitFor,
+        waitForElementToBeRemoved,
+      } = require('..'))
     })
 
-    afterEach(() => {
+    afterEach(async () => {
+      await cleanup()
+      global.IS_REACT_ACT_ENVIRONMENT = false
       jest.useRealTimers()
     })
 
@@ -206,29 +247,125 @@ describe.each([
       )
     }
 
-    test('waitForElementToBeRemoved', async () => {
-      render(<ComponentWithMicrotaskLoader />)
-      const loading = () => screen.getByText('Loading..')
-      await waitForElementToBeRemoved(loading)
-      expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
-    })
-
     test('waitFor', async () => {
-      render(<ComponentWithMicrotaskLoader />)
-      await waitFor(() => {
-        screen.getByText('Loading..')
-      })
-      await waitFor(() => {
-        screen.getByText(/Loaded this message:/)
-      })
+      await render(<ComponentWithMicrotaskLoader />)
+      // Already flushed microtasks from `ComponentWithMicrotaskLoader` here.
+      expect(screen.queryByText('Loading..')).not.toBeInTheDocument()
+      expect(screen.getByText(/Loaded this message:/)).toBeInTheDocument()
       expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
     })
 
     test('findBy', async () => {
-      render(<ComponentWithMicrotaskLoader />)
+      await render(<ComponentWithMicrotaskLoader />)
       await expect(screen.findByTestId('message')).resolves.toHaveTextContent(
         /Hello World/,
       )
     })
   },
 )
+
+describe.each([
+  ['real timers', () => jest.useRealTimers()],
+  ['fake legacy timers', () => jest.useFakeTimers('legacy')],
+  ['fake modern timers', () => jest.useFakeTimers('modern')],
+])('testing intermediate states using %s', (label, useTimers) => {
+  let isReact18
+
+  beforeEach(() => {
+    jest.resetModules()
+    global.IS_REACT_ACT_ENVIRONMENT = false
+    process.env.RTL_SKIP_AUTO_CLEANUP = '0'
+
+    useTimers()
+
+    React = require('react')
+    isReact18 = typeof React.use !== 'function'
+    ;({
+      cleanup,
+      render,
+      screen,
+      waitFor,
+      waitForElementToBeRemoved,
+    } = require('..'))
+  })
+
+  afterEach(async () => {
+    await cleanup()
+    jest.useRealTimers()
+    global.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  const fetchAMessageInAMicrotask = () =>
+    Promise.resolve({
+      status: 200,
+      json: () => Promise.resolve({title: 'Hello World'}),
+    })
+
+  function ComponentWithMicrotaskLoader() {
+    const [fetchState, setFetchState] = React.useState({fetching: true})
+
+    React.useEffect(() => {
+      if (fetchState.fetching) {
+        fetchAMessageInAMicrotask().then(res => {
+          return res.json().then(data => {
+            setFetchState({todo: data.title, fetching: false})
+          })
+        })
+      }
+    }, [fetchState])
+
+    if (fetchState.fetching) {
+      return <p>Loading..</p>
+    }
+
+    return (
+      <div data-testid="message">Loaded this message: {fetchState.todo}</div>
+    )
+  }
+
+  test('waitFor', async () => {
+    const {container} = await render(<ComponentWithMicrotaskLoader />)
+
+    if (isReact18 && label !== 'real timers') {
+      // React 18 has no sync updates by default so we need to wait for the commit.
+      expect(container).toHaveProperty('textContent', '')
+
+      await waitFor(() => {
+        expect(container).not.toHaveProperty('textContent', '')
+      })
+
+      // But we can't assert on the intermediate state.
+      expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
+    } else {
+      await waitFor(() => {
+        expect(screen.getByText('Loading..')).toBeInTheDocument()
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
+      })
+    }
+  })
+
+  test('findBy', async () => {
+    const {container} = await render(<ComponentWithMicrotaskLoader />)
+
+    if (isReact18 && label !== 'real timers') {
+      // React 18 has no sync updates by default so we need to wait for the commit.
+      expect(container).toHaveProperty('textContent', '')
+
+      await expect(screen.findByText('Loading..')).rejects.toThrow(
+        'Unable to find an element',
+      )
+
+      // But we can't assert on the intermediate state.
+      expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
+    } else {
+      await expect(screen.findByText('Loading..')).resolves.toBeInTheDocument()
+
+      await expect(
+        screen.findByText(/Loaded this message:/),
+      ).resolves.toBeInTheDocument()
+    }
+  })
+})

--- a/src/__tests__/error-handlers.js
+++ b/src/__tests__/error-handlers.js
@@ -8,20 +8,20 @@ const isReact19 = React.version.startsWith('19.')
 
 const testGateReact19 = isReact19 ? test : test.skip
 
-test('render errors', () => {
+test('render errors', async () => {
   function Thrower() {
     throw new Error('Boom!')
   }
 
   if (isReact19) {
-    expect(() => {
-      render(<Thrower />)
-    }).toThrow('Boom!')
+    await expect(async () => {
+      await render(<Thrower />)
+    }).rejects.toThrow('Boom!')
   } else {
-    expect(() => {
-      expect(() => {
-        render(<Thrower />)
-      }).toThrow('Boom!')
+    await expect(async () => {
+      await expect(async () => {
+        await render(<Thrower />)
+      }).rejects.toThrow('Boom!')
     }).toErrorDev([
       'Error: Uncaught [Error: Boom!]',
       // React retries on error
@@ -30,26 +30,26 @@ test('render errors', () => {
   }
 })
 
-test('onUncaughtError is not supported in render', () => {
+test('onUncaughtError is not supported in render', async () => {
   function Thrower() {
     throw new Error('Boom!')
   }
   const onUncaughtError = jest.fn(() => {})
 
-  expect(() => {
-    render(<Thrower />, {
+  await expect(async () => {
+    await render(<Thrower />, {
       onUncaughtError(error, errorInfo) {
         console.log({error, errorInfo})
       },
     })
-  }).toThrow(
+  }).rejects.toThrow(
     'onUncaughtError is not supported. The `render` call will already throw on uncaught errors.',
   )
 
   expect(onUncaughtError).toHaveBeenCalledTimes(0)
 })
 
-testGateReact19('onCaughtError is supported in render', () => {
+testGateReact19('onCaughtError is supported in render', async () => {
   const thrownError = new Error('Boom!')
   const handleComponentDidCatch = jest.fn()
   const onCaughtError = jest.fn()
@@ -72,7 +72,7 @@ testGateReact19('onCaughtError is supported in render', () => {
     throw thrownError
   }
 
-  render(
+  await render(
     <ErrorBoundary>
       <Thrower />
     </ErrorBoundary>,
@@ -87,7 +87,7 @@ testGateReact19('onCaughtError is supported in render', () => {
   })
 })
 
-test('onRecoverableError is supported in render', () => {
+test('onRecoverableError is supported in render', async () => {
   const onRecoverableError = jest.fn()
 
   const container = document.createElement('div')
@@ -96,15 +96,15 @@ test('onRecoverableError is supported in render', () => {
   // Frankly, I'm too lazy to assert on React 18 hydration errors since they're a mess.
   // eslint-disable-next-line jest/no-conditional-in-test
   if (isReact19) {
-    render(<div>client</div>, {
+    await render(<div>client</div>, {
       container,
       hydrate: true,
       onRecoverableError,
     })
     expect(onRecoverableError).toHaveBeenCalledTimes(1)
   } else {
-    expect(() => {
-      render(<div>client</div>, {
+    await expect(async () => {
+      await render(<div>client</div>, {
         container,
         hydrate: true,
         onRecoverableError,
@@ -114,26 +114,26 @@ test('onRecoverableError is supported in render', () => {
   }
 })
 
-test('onUncaughtError is not supported in renderHook', () => {
+test('onUncaughtError is not supported in renderHook', async () => {
   function useThrower() {
     throw new Error('Boom!')
   }
   const onUncaughtError = jest.fn(() => {})
 
-  expect(() => {
-    renderHook(useThrower, {
+  await expect(async () => {
+    await renderHook(useThrower, {
       onUncaughtError(error, errorInfo) {
         console.log({error, errorInfo})
       },
     })
-  }).toThrow(
+  }).rejects.toThrow(
     'onUncaughtError is not supported. The `render` call will already throw on uncaught errors.',
   )
 
   expect(onUncaughtError).toHaveBeenCalledTimes(0)
 })
 
-testGateReact19('onCaughtError is supported in renderHook', () => {
+testGateReact19('onCaughtError is supported in renderHook', async () => {
   const thrownError = new Error('Boom!')
   const handleComponentDidCatch = jest.fn()
   const onCaughtError = jest.fn()
@@ -156,7 +156,7 @@ testGateReact19('onCaughtError is supported in renderHook', () => {
     throw thrownError
   }
 
-  renderHook(useThrower, {
+  await renderHook(useThrower, {
     onCaughtError,
     wrapper: ErrorBoundary,
   })
@@ -169,10 +169,10 @@ testGateReact19('onCaughtError is supported in renderHook', () => {
 
 // Currently, there's no recoverable error without hydration.
 // The option is still supported though.
-test('onRecoverableError is supported in renderHook', () => {
+test('onRecoverableError is supported in renderHook', async () => {
   const onRecoverableError = jest.fn()
 
-  renderHook(
+  await renderHook(
     () => {
       // TODO: trigger recoverable error
     },

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -151,18 +151,18 @@ eventTypes.forEach(({type, events, elementType, init}) => {
         1,
       )}`
 
-      it(`triggers ${propName}`, () => {
+      it(`triggers ${propName}`, async () => {
         const ref = React.createRef()
         const spy = jest.fn()
 
-        render(
+        await render(
           React.createElement(elementType, {
             [propName]: spy,
             ref,
           }),
         )
 
-        fireEvent[eventName](ref.current, init)
+        await fireEvent[eventName](ref.current, init)
         expect(spy).toHaveBeenCalledTimes(1)
       })
     })
@@ -179,7 +179,7 @@ eventTypes.forEach(({type, events, elementType, init}) => {
         nativeEventName = 'dblclick'
       }
 
-      it(`triggers native ${nativeEventName}`, () => {
+      it(`triggers native ${nativeEventName}`, async () => {
         const ref = React.createRef()
         const spy = jest.fn()
         const Element = elementType
@@ -195,30 +195,30 @@ eventTypes.forEach(({type, events, elementType, init}) => {
           return <Element ref={ref} />
         }
 
-        render(<NativeEventElement />)
+        await render(<NativeEventElement />)
 
-        fireEvent[eventName](ref.current, init)
+        await fireEvent[eventName](ref.current, init)
         expect(spy).toHaveBeenCalledTimes(1)
       })
     })
   })
 })
 
-test('onChange works', () => {
+test('onChange works', async () => {
   const handleChange = jest.fn()
   const {
     container: {firstChild: input},
-  } = render(<input onChange={handleChange} />)
-  fireEvent.change(input, {target: {value: 'a'}})
+  } = await render(<input onChange={handleChange} />)
+  await fireEvent.change(input, {target: {value: 'a'}})
   expect(handleChange).toHaveBeenCalledTimes(1)
 })
 
-test('calling `fireEvent` directly works too', () => {
+test('calling `fireEvent` directly works too', async () => {
   const handleEvent = jest.fn()
   const {
     container: {firstChild: button},
-  } = render(<button onClick={handleEvent} />)
-  fireEvent(
+  } = await render(<button onClick={handleEvent} />)
+  await fireEvent(
     button,
     new Event('MouseEvent', {
       bubbles: true,
@@ -228,26 +228,26 @@ test('calling `fireEvent` directly works too', () => {
   )
 })
 
-test('blur/focus bubbles in react', () => {
+test('blur/focus bubbles in react', async () => {
   const handleBlur = jest.fn()
   const handleBubbledBlur = jest.fn()
   const handleFocus = jest.fn()
   const handleBubbledFocus = jest.fn()
-  const {container} = render(
+  const {container} = await render(
     <div onBlur={handleBubbledBlur} onFocus={handleBubbledFocus}>
       <button onBlur={handleBlur} onFocus={handleFocus} />
     </div>,
   )
   const button = container.firstChild.firstChild
 
-  fireEvent.focus(button)
+  await fireEvent.focus(button)
 
   expect(handleBlur).toHaveBeenCalledTimes(0)
   expect(handleBubbledBlur).toHaveBeenCalledTimes(0)
   expect(handleFocus).toHaveBeenCalledTimes(1)
   expect(handleBubbledFocus).toHaveBeenCalledTimes(1)
 
-  fireEvent.blur(button)
+  await fireEvent.blur(button)
 
   expect(handleBlur).toHaveBeenCalledTimes(1)
   expect(handleBubbledBlur).toHaveBeenCalledTimes(1)

--- a/src/__tests__/multi-base.js
+++ b/src/__tests__/multi-base.js
@@ -15,11 +15,11 @@ afterAll(() => {
   treeB.parentNode.removeChild(treeB)
 })
 
-test('baseElement isolates trees from one another', () => {
-  const {getByText: getByTextInA} = render(<div>Jekyll</div>, {
+test('baseElement isolates trees from one another', async () => {
+  const {getByText: getByTextInA} = await render(<div>Jekyll</div>, {
     baseElement: treeA,
   })
-  const {getByText: getByTextInB} = render(<div>Hyde</div>, {
+  const {getByText: getByTextInB} = await render(<div>Hyde</div>, {
     baseElement: treeB,
   })
 

--- a/src/__tests__/new-act.js
+++ b/src/__tests__/new-act.js
@@ -1,4 +1,4 @@
-let asyncAct
+let actIfEnabled
 
 jest.mock('react', () => {
   return {
@@ -11,7 +11,7 @@ jest.mock('react', () => {
 
 beforeEach(() => {
   jest.resetModules()
-  asyncAct = require('../act-compat').default
+  actIfEnabled = require('../act-compat').actIfEnabled
   jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
@@ -21,7 +21,7 @@ afterEach(() => {
 
 test('async act works when it does not exist (older versions of react)', async () => {
   const callback = jest.fn()
-  await asyncAct(async () => {
+  await actIfEnabled(async () => {
     await Promise.resolve()
     await callback()
   })
@@ -31,7 +31,7 @@ test('async act works when it does not exist (older versions of react)', async (
   callback.mockClear()
   console.error.mockClear()
 
-  await asyncAct(async () => {
+  await actIfEnabled(async () => {
     await Promise.resolve()
     await callback()
   })
@@ -41,7 +41,7 @@ test('async act works when it does not exist (older versions of react)', async (
 
 test('async act recovers from errors', async () => {
   try {
-    await asyncAct(async () => {
+    await actIfEnabled(async () => {
       await null
       throw new Error('test error')
     })
@@ -60,7 +60,7 @@ test('async act recovers from errors', async () => {
 
 test('async act recovers from sync errors', async () => {
   try {
-    await asyncAct(() => {
+    await actIfEnabled(() => {
       throw new Error('test error')
     })
   } catch (err) {

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -25,13 +25,13 @@ describe('render API', () => {
     configure(originalConfig)
   })
 
-  test('renders div into document', () => {
+  test('renders div into document', async () => {
     const ref = React.createRef()
-    const {container} = render(<div ref={ref} />)
+    const {container} = await render(<div ref={ref} />)
     expect(container.firstChild).toBe(ref.current)
   })
 
-  test('works great with react portals', () => {
+  test('works great with react portals', async () => {
     class MyPortal extends React.Component {
       constructor(...args) {
         super(...args)
@@ -62,20 +62,20 @@ describe('render API', () => {
       )
     }
 
-    const {unmount} = render(<MyPortal />)
+    const {unmount} = await render(<MyPortal />)
     expect(screen.getByText('Hello World')).toBeInTheDocument()
     const portalNode = screen.getByTestId('my-portal')
     expect(portalNode).toBeInTheDocument()
-    unmount()
+    await unmount()
     expect(portalNode).not.toBeInTheDocument()
   })
 
-  test('returns baseElement which defaults to document.body', () => {
-    const {baseElement} = render(<div />)
+  test('returns baseElement which defaults to document.body', async () => {
+    const {baseElement} = await render(<div />)
     expect(baseElement).toBe(document.body)
   })
 
-  test('supports fragments', () => {
+  test('supports fragments', async () => {
     class Test extends React.Component {
       render() {
         return (
@@ -86,16 +86,16 @@ describe('render API', () => {
       }
     }
 
-    const {asFragment} = render(<Test />)
+    const {asFragment} = await render(<Test />)
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test('renders options.wrapper around node', () => {
+  test('renders options.wrapper around node', async () => {
     const WrapperComponent = ({children}) => (
       <div data-testid="wrapper">{children}</div>
     )
 
-    const {container} = render(<div data-testid="inner" />, {
+    const {container} = await render(<div data-testid="inner" />, {
       wrapper: WrapperComponent,
     })
 
@@ -111,13 +111,13 @@ describe('render API', () => {
   `)
   })
 
-  test('renders options.wrapper around node when reactStrictMode is true', () => {
+  test('renders options.wrapper around node when reactStrictMode is true', async () => {
     configure({reactStrictMode: true})
 
     const WrapperComponent = ({children}) => (
       <div data-testid="wrapper">{children}</div>
     )
-    const {container} = render(<div data-testid="inner" />, {
+    const {container} = await render(<div data-testid="inner" />, {
       wrapper: WrapperComponent,
     })
 
@@ -133,7 +133,7 @@ describe('render API', () => {
   `)
   })
 
-  test('renders twice when reactStrictMode is true', () => {
+  test('renders twice when reactStrictMode is true', async () => {
     configure({reactStrictMode: true})
 
     const spy = jest.fn()
@@ -142,41 +142,41 @@ describe('render API', () => {
       return null
     }
 
-    render(<Component />)
+    await render(<Component />)
     expect(spy).toHaveBeenCalledTimes(2)
   })
 
-  test('flushes useEffect cleanup functions sync on unmount()', () => {
+  test('flushes useEffect cleanup functions sync on unmount()', async () => {
     const spy = jest.fn()
     function Component() {
       React.useEffect(() => spy, [])
       return null
     }
-    const {unmount} = render(<Component />)
+    const {unmount} = await render(<Component />)
     expect(spy).toHaveBeenCalledTimes(0)
 
-    unmount()
+    await unmount()
 
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  test('can be called multiple times on the same container', () => {
+  test('can be called multiple times on the same container', async () => {
     const container = document.createElement('div')
 
-    const {unmount} = render(<strong />, {container})
+    const {unmount} = await render(<strong />, {container})
 
     expect(container).toContainHTML('<strong></strong>')
 
-    render(<em />, {container})
+    await render(<em />, {container})
 
     expect(container).toContainHTML('<em></em>')
 
-    unmount()
+    await unmount()
 
     expect(container).toBeEmptyDOMElement()
   })
 
-  test('hydrate will make the UI interactive', () => {
+  test('hydrate will make the UI interactive', async () => {
     function App() {
       const [clicked, handleClick] = React.useReducer(n => n + 1, 0)
 
@@ -193,14 +193,14 @@ describe('render API', () => {
 
     expect(container).toHaveTextContent('clicked:0')
 
-    render(ui, {container, hydrate: true})
+    await render(ui, {container, hydrate: true})
 
-    fireEvent.click(container.querySelector('button'))
+    await fireEvent.click(container.querySelector('button'))
 
     expect(container).toHaveTextContent('clicked:1')
   })
 
-  test('hydrate can have a wrapper', () => {
+  test('hydrate can have a wrapper', async () => {
     const wrapperComponentMountEffect = jest.fn()
     function WrapperComponent({children}) {
       React.useEffect(() => {
@@ -214,14 +214,14 @@ describe('render API', () => {
     document.body.appendChild(container)
     container.innerHTML = ReactDOMServer.renderToString(ui)
 
-    render(ui, {container, hydrate: true, wrapper: WrapperComponent})
+    await render(ui, {container, hydrate: true, wrapper: WrapperComponent})
 
     expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(1)
   })
 
-  testGateReact18('legacyRoot uses legacy ReactDOM.render', () => {
-    expect(() => {
-      render(<div />, {legacyRoot: true})
+  testGateReact18('legacyRoot uses legacy ReactDOM.render', async () => {
+    await expect(async () => {
+      await render(<div />, {legacyRoot: true})
     }).toErrorDev(
       [
         "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
@@ -230,20 +230,20 @@ describe('render API', () => {
     )
   })
 
-  testGateReact19('legacyRoot throws', () => {
-    expect(() => {
-      render(<div />, {legacyRoot: true})
-    }).toThrowErrorMatchingInlineSnapshot(
+  testGateReact19('legacyRoot throws', async () => {
+    await expect(async () => {
+      await render(<div />, {legacyRoot: true})
+    }).rejects.toThrowErrorMatchingInlineSnapshot(
       `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.`,
     )
   })
 
-  testGateReact18('legacyRoot uses legacy ReactDOM.hydrate', () => {
+  testGateReact18('legacyRoot uses legacy ReactDOM.hydrate', async () => {
     const ui = <div />
     const container = document.createElement('div')
     container.innerHTML = ReactDOMServer.renderToString(ui)
-    expect(() => {
-      render(ui, {container, hydrate: true, legacyRoot: true})
+    await expect(async () => {
+      await render(ui, {container, hydrate: true, legacyRoot: true})
     }).toErrorDev(
       [
         "Warning: ReactDOM.hydrate is no longer supported in React 18. Use hydrateRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
@@ -252,18 +252,18 @@ describe('render API', () => {
     )
   })
 
-  testGateReact19('legacyRoot throws even with hydrate', () => {
+  testGateReact19('legacyRoot throws even with hydrate', async () => {
     const ui = <div />
     const container = document.createElement('div')
     container.innerHTML = ReactDOMServer.renderToString(ui)
-    expect(() => {
-      render(ui, {container, hydrate: true, legacyRoot: true})
-    }).toThrowErrorMatchingInlineSnapshot(
+    await expect(
+      render(ui, {container, hydrate: true, legacyRoot: true}),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.`,
     )
   })
 
-  test('reactStrictMode in renderOptions has precedence over config when rendering', () => {
+  test('reactStrictMode in renderOptions has precedence over config when rendering', async () => {
     const wrapperComponentMountEffect = jest.fn()
     function WrapperComponent({children}) {
       React.useEffect(() => {
@@ -275,12 +275,12 @@ describe('render API', () => {
     const ui = <div />
     configure({reactStrictMode: false})
 
-    render(ui, {wrapper: WrapperComponent, reactStrictMode: true})
+    await render(ui, {wrapper: WrapperComponent, reactStrictMode: true})
 
     expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(2)
   })
 
-  test('reactStrictMode in config is used when renderOptions does not specify reactStrictMode', () => {
+  test('reactStrictMode in config is used when renderOptions does not specify reactStrictMode', async () => {
     const wrapperComponentMountEffect = jest.fn()
     function WrapperComponent({children}) {
       React.useEffect(() => {
@@ -292,7 +292,7 @@ describe('render API', () => {
     const ui = <div />
     configure({reactStrictMode: true})
 
-    render(ui, {wrapper: WrapperComponent})
+    await render(ui, {wrapper: WrapperComponent})
 
     expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(2)
   })

--- a/src/__tests__/rerender.js
+++ b/src/__tests__/rerender.js
@@ -17,22 +17,22 @@ describe('rerender API', () => {
     configure(originalConfig)
   })
 
-  test('rerender will re-render the element', () => {
+  test('rerender will re-render the element', async () => {
     const Greeting = props => <div>{props.message}</div>
-    const {container, rerender} = render(<Greeting message="hi" />)
+    const {container, rerender} = await render(<Greeting message="hi" />)
     expect(container.firstChild).toHaveTextContent('hi')
-    rerender(<Greeting message="hey" />)
+    await rerender(<Greeting message="hey" />)
     expect(container.firstChild).toHaveTextContent('hey')
   })
 
-  test('hydrate will not update props until next render', () => {
+  test('hydrate will not update props until next render', async () => {
     const initialInputElement = document.createElement('input')
     const container = document.createElement('div')
     container.appendChild(initialInputElement)
     document.body.appendChild(container)
 
     const firstValue = 'hello'
-    const {rerender} = render(
+    const {rerender} = await render(
       <input value={firstValue} onChange={() => null} />,
       {
         container,
@@ -43,18 +43,18 @@ describe('rerender API', () => {
     expect(initialInputElement).toHaveValue(firstValue)
 
     const secondValue = 'goodbye'
-    rerender(<input value={secondValue} onChange={() => null} />)
+    await rerender(<input value={secondValue} onChange={() => null} />)
     expect(initialInputElement).toHaveValue(secondValue)
   })
 
-  test('re-renders options.wrapper around node when reactStrictMode is true', () => {
+  test('re-renders options.wrapper around node when reactStrictMode is true', async () => {
     configure({reactStrictMode: true})
 
     const WrapperComponent = ({children}) => (
       <div data-testid="wrapper">{children}</div>
     )
     const Greeting = props => <div>{props.message}</div>
-    const {container, rerender} = render(<Greeting message="hi" />, {
+    const {container, rerender} = await render(<Greeting message="hi" />, {
       wrapper: WrapperComponent,
     })
 
@@ -68,7 +68,7 @@ describe('rerender API', () => {
     </div>
   `)
 
-    rerender(<Greeting message="hey" />)
+    await rerender(<Greeting message="hey" />)
     expect(container.firstChild).toMatchInlineSnapshot(`
     <div
       data-testid=wrapper
@@ -80,7 +80,7 @@ describe('rerender API', () => {
   `)
   })
 
-  test('re-renders twice when reactStrictMode is true', () => {
+  test('re-renders twice when reactStrictMode is true', async () => {
     configure({reactStrictMode: true})
 
     const spy = jest.fn()
@@ -89,11 +89,11 @@ describe('rerender API', () => {
       return null
     }
 
-    const {rerender} = render(<Component />)
+    const {rerender} = await render(<Component />)
     expect(spy).toHaveBeenCalledTimes(2)
 
     spy.mockClear()
-    rerender(<Component />)
+    await rerender(<Component />)
     expect(spy).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/__tests__/stopwatch.js
+++ b/src/__tests__/stopwatch.js
@@ -40,9 +40,9 @@ class StopWatch extends React.Component {
 const sleep = t => new Promise(resolve => setTimeout(resolve, t))
 
 test('unmounts a component', async () => {
-  const {unmount, container} = render(<StopWatch />)
-  fireEvent.click(screen.getByText('Start'))
-  unmount()
+  const {unmount, container} = await render(<StopWatch />)
+  await fireEvent.click(screen.getByText('Start'))
+  await unmount()
   // hey there reader! You don't need to have an assertion like this one
   // this is just me making sure that the unmount function works.
   // You don't need to do this in your apps. Just rely on the fact that this works.

--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -15,29 +15,29 @@ Object.keys(dtlFireEvent).forEach(key => {
 // @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/EnterLeaveEventPlugin.js#L24-L31
 const mouseEnter = fireEvent.mouseEnter
 const mouseLeave = fireEvent.mouseLeave
-fireEvent.mouseEnter = (...args) => {
-  mouseEnter(...args)
+fireEvent.mouseEnter = async (...args) => {
+  await mouseEnter(...args)
   return fireEvent.mouseOver(...args)
 }
-fireEvent.mouseLeave = (...args) => {
-  mouseLeave(...args)
+fireEvent.mouseLeave = async (...args) => {
+  await mouseLeave(...args)
   return fireEvent.mouseOut(...args)
 }
 
 const pointerEnter = fireEvent.pointerEnter
 const pointerLeave = fireEvent.pointerLeave
-fireEvent.pointerEnter = (...args) => {
-  pointerEnter(...args)
+fireEvent.pointerEnter = async (...args) => {
+  await pointerEnter(...args)
   return fireEvent.pointerOver(...args)
 }
-fireEvent.pointerLeave = (...args) => {
-  pointerLeave(...args)
+fireEvent.pointerLeave = async (...args) => {
+  await pointerLeave(...args)
   return fireEvent.pointerOut(...args)
 }
 
 const select = fireEvent.select
-fireEvent.select = (node, init) => {
-  select(node, init)
+fireEvent.select = async (node, init) => {
+  await select(node, init)
   // React tracks this event only on focused inputs
   node.focus()
 
@@ -49,7 +49,7 @@ fireEvent.select = (node, init) => {
   // - keyDown
   // so we can use any here
   // @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/SelectEventPlugin.js#L203-L224
-  fireEvent.keyUp(node, init)
+  await fireEvent.keyUp(node, init)
 }
 
 // React event system tracks native focusout/focusin events for
@@ -57,12 +57,12 @@ fireEvent.select = (node, init) => {
 // @link https://github.com/facebook/react/pull/19186
 const blur = fireEvent.blur
 const focus = fireEvent.focus
-fireEvent.blur = (...args) => {
-  fireEvent.focusOut(...args)
+fireEvent.blur = async (...args) => {
+  await fireEvent.focusOut(...args)
   return blur(...args)
 }
-fireEvent.focus = (...args) => {
-  fireEvent.focusIn(...args)
+fireEvent.focus = async (...args) => {
+  await fireEvent.focusIn(...args)
   return focus(...args)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {getIsReactActEnvironment, setReactActEnvironment} from './act-compat'
+import {getIsReactActEnvironment, setIsReactActEnvironment} from './act-compat'
 import {cleanup} from './pure'
 
 // if we're running in a test runner that supports afterEach
@@ -10,15 +10,15 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
   // ignore teardown() in code coverage because Jest does not support it
   /* istanbul ignore else */
   if (typeof afterEach === 'function') {
-    afterEach(() => {
-      cleanup()
+    afterEach(async () => {
+      await cleanup()
     })
   } else if (typeof teardown === 'function') {
     // Block is guarded by `typeof` check.
     // eslint does not support `typeof` guards.
     // eslint-disable-next-line no-undef
-    teardown(() => {
-      cleanup()
+    teardown(async () => {
+      await cleanup()
     })
   }
 
@@ -29,11 +29,11 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
     let previousIsReactActEnvironment = getIsReactActEnvironment()
     beforeAll(() => {
       previousIsReactActEnvironment = getIsReactActEnvironment()
-      setReactActEnvironment(true)
+      setIsReactActEnvironment(true)
     })
 
     afterAll(() => {
-      setReactActEnvironment(previousIsReactActEnvironment)
+      setIsReactActEnvironment(previousIsReactActEnvironment)
     })
   }
 }

--- a/src/pure.js
+++ b/src/pure.js
@@ -32,18 +32,14 @@ async function waitForMicrotasks() {
 
 configureDTL({
   unstable_advanceTimersWrapper: async scope => {
-    if (getIsReactActEnvironment()) {
-      return actIfEnabled(scope)
-    } else {
-      const result = await scope()
-      await waitForMicrotasks()
-      return result
-    }
+    const result = await scope()
+    await waitForMicrotasks()
+    return result
   },
-  // We just want to run `waitFor` without IS_REACT_ACT_ENVIRONMENT
-  // But that's not necessarily how `asyncWrapper` is used since it's a public method.
-  // Let's just hope nobody else is using it.
-  asyncWrapper: async cb => {
+  eventWrapper: actIfEnabled,
+  asyncWrapper: actIfEnabled,
+  // Run `waitFor` without IS_REACT_ACT_ENVIRONMENT
+  waitForWrapper: async cb => {
     const previousActEnvironment = getIsReactActEnvironment()
     setIsReactActEnvironment(false)
     try {
@@ -52,7 +48,6 @@ configureDTL({
       setIsReactActEnvironment(previousActEnvironment)
     }
   },
-  eventWrapper: actIfEnabled,
 })
 
 // Ideally we'd just use a WeakMap where containers are keys and roots are values.

--- a/src/pure.js
+++ b/src/pure.js
@@ -1,69 +1,58 @@
 import * as React from 'react'
 import ReactDOM from 'react-dom'
+import * as DeprecatedReactTestUtils from 'react-dom/test-utils'
 import * as ReactDOMClient from 'react-dom/client'
 import {
   getQueriesForElement,
   prettyDOM,
   configure as configureDTL,
 } from '@testing-library/dom'
-import act, {
+import {
+  actIfEnabled,
   getIsReactActEnvironment,
-  setReactActEnvironment,
+  setIsReactActEnvironment,
 } from './act-compat'
 import {fireEvent} from './fire-event'
 import {getConfig, configure} from './config'
 
-function jestFakeTimersAreEnabled() {
-  /* istanbul ignore else */
-  if (typeof jest !== 'undefined' && jest !== null) {
-    return (
-      // legacy timers
-      setTimeout._isMockFunction === true || // modern timers
-      // eslint-disable-next-line prefer-object-has-own -- No Object.hasOwn in all target environments we support.
-      Object.prototype.hasOwnProperty.call(setTimeout, 'clock')
-    )
-  } // istanbul ignore next
+function enqueueTask(task) {
+  const channel = new MessageChannel()
+  channel.port1.onmessage = () => {
+    channel.port1.close()
+    task()
+  }
+  channel.port2.postMessage(undefined)
+}
 
-  return false
+async function waitForMicrotasks() {
+  return new Promise(resolve => {
+    enqueueTask(() => resolve())
+  })
 }
 
 configureDTL({
-  unstable_advanceTimersWrapper: cb => {
-    return act(cb)
+  unstable_advanceTimersWrapper: async scope => {
+    if (getIsReactActEnvironment()) {
+      return actIfEnabled(scope)
+    } else {
+      const result = await scope()
+      await waitForMicrotasks()
+      return result
+    }
   },
   // We just want to run `waitFor` without IS_REACT_ACT_ENVIRONMENT
   // But that's not necessarily how `asyncWrapper` is used since it's a public method.
   // Let's just hope nobody else is using it.
   asyncWrapper: async cb => {
     const previousActEnvironment = getIsReactActEnvironment()
-    setReactActEnvironment(false)
+    setIsReactActEnvironment(false)
     try {
-      const result = await cb()
-      // Drain microtask queue.
-      // Otherwise we'll restore the previous act() environment, before we resolve the `waitFor` call.
-      // The caller would have no chance to wrap the in-flight Promises in `act()`
-      await new Promise(resolve => {
-        setTimeout(() => {
-          resolve()
-        }, 0)
-
-        if (jestFakeTimersAreEnabled()) {
-          jest.advanceTimersByTime(0)
-        }
-      })
-
-      return result
+      return await cb()
     } finally {
-      setReactActEnvironment(previousActEnvironment)
+      setIsReactActEnvironment(previousActEnvironment)
     }
   },
-  eventWrapper: cb => {
-    let result
-    act(() => {
-      result = cb()
-    })
-    return result
-  },
+  eventWrapper: actIfEnabled,
 })
 
 // Ideally we'd just use a WeakMap where containers are keys and roots are values.
@@ -89,7 +78,7 @@ function wrapUiIfNeeded(innerElement, wrapperComponent) {
     : innerElement
 }
 
-function createConcurrentRoot(
+async function createConcurrentRoot(
   container,
   {
     hydrate,
@@ -102,7 +91,7 @@ function createConcurrentRoot(
 ) {
   let root
   if (hydrate) {
-    act(() => {
+    await actIfEnabled(() => {
       root = ReactDOMClient.hydrateRoot(
         container,
         strictModeIfNeeded(
@@ -130,29 +119,39 @@ function createConcurrentRoot(
       // Nothing to do since hydration happens when creating the root object.
     },
     render(element) {
-      root.render(element)
+      return actIfEnabled(() => {
+        root.render(element)
+      })
     },
     unmount() {
-      root.unmount()
+      return actIfEnabled(() => {
+        root.unmount()
+      })
     },
   }
 }
 
-function createLegacyRoot(container) {
+async function createLegacyRoot(container) {
   return {
     hydrate(element) {
-      ReactDOM.hydrate(element, container)
+      return actIfEnabled(() => {
+        ReactDOM.hydrate(element, container)
+      })
     },
     render(element) {
-      ReactDOM.render(element, container)
+      return actIfEnabled(() => {
+        ReactDOM.render(element, container)
+      })
     },
     unmount() {
-      ReactDOM.unmountComponentAtNode(container)
+      return actIfEnabled(() => {
+        ReactDOM.unmountComponentAtNode(container)
+      })
     },
   }
 }
 
-function renderRoot(
+async function renderRoot(
   ui,
   {
     baseElement,
@@ -164,25 +163,17 @@ function renderRoot(
     reactStrictMode,
   },
 ) {
-  act(() => {
-    if (hydrate) {
-      root.hydrate(
-        strictModeIfNeeded(
-          wrapUiIfNeeded(ui, WrapperComponent),
-          reactStrictMode,
-        ),
-        container,
-      )
-    } else {
-      root.render(
-        strictModeIfNeeded(
-          wrapUiIfNeeded(ui, WrapperComponent),
-          reactStrictMode,
-        ),
-        container,
-      )
-    }
-  })
+  if (hydrate) {
+    await root.hydrate(
+      strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent), reactStrictMode),
+      container,
+    )
+  } else {
+    await root.render(
+      strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent), reactStrictMode),
+      container,
+    )
+  }
 
   return {
     container,
@@ -194,12 +185,10 @@ function renderRoot(
         : // eslint-disable-next-line no-console,
           console.log(prettyDOM(el, maxLength, options)),
     unmount: () => {
-      act(() => {
-        root.unmount()
-      })
+      return root.unmount()
     },
-    rerender: rerenderUi => {
-      renderRoot(rerenderUi, {
+    rerender: async rerenderUi => {
+      await renderRoot(rerenderUi, {
         container,
         baseElement,
         root,
@@ -225,7 +214,7 @@ function renderRoot(
   }
 }
 
-function render(
+async function render(
   ui,
   {
     container,
@@ -268,7 +257,7 @@ function render(
   // eslint-disable-next-line no-negated-condition -- we want to map the evolution of this over time. The root is created first. Only later is it re-used so we don't want to read the case that happens later first.
   if (!mountedContainers.has(container)) {
     const createRootImpl = legacyRoot ? createLegacyRoot : createConcurrentRoot
-    root = createRootImpl(container, {
+    root = await createRootImpl(container, {
       hydrate,
       onCaughtError,
       onRecoverableError,
@@ -304,20 +293,20 @@ function render(
   })
 }
 
-function cleanup() {
-  mountedRootEntries.forEach(({root, container}) => {
-    act(() => {
-      root.unmount()
-    })
+async function cleanup() {
+  for (const {container, root} of mountedRootEntries) {
+    // eslint-disable-next-line no-await-in-loop -- Overlapping act calls are not allowed.
+    await root.unmount()
     if (container.parentNode === document.body) {
       document.body.removeChild(container)
     }
-  })
+  }
+
   mountedRootEntries.length = 0
   mountedContainers.clear()
 }
 
-function renderHook(renderCallback, options = {}) {
+async function renderHook(renderCallback, options = {}) {
   const {initialProps, ...renderOptions} = options
 
   if (renderOptions.legacyRoot && typeof ReactDOM.render !== 'function') {
@@ -342,7 +331,7 @@ function renderHook(renderCallback, options = {}) {
     return null
   }
 
-  const {rerender: baseRerender, unmount} = render(
+  const {rerender: baseRerender, unmount} = await render(
     <TestComponent renderCallbackProps={initialProps} />,
     renderOptions,
   )
@@ -354,6 +343,18 @@ function renderHook(renderCallback, options = {}) {
   }
 
   return {result, rerender, unmount}
+}
+
+const reactAct =
+  typeof React.act === 'function' ? React.act : DeprecatedReactTestUtils.act
+
+function act(scope) {
+  // scope passed to reactAct needs to be `async` until React.act treats every scope as async.
+  // We already enforce `await act()` (regardless of scope) to flush microtasks
+  // inside the act scope.
+  return reactAct(async () => {
+    return scope()
+  })
 }
 
 // just re-export everything from dom-testing-library

--- a/tests/toWarnDev.js
+++ b/tests/toWarnDev.js
@@ -181,11 +181,7 @@ const createMatcherFor = (consoleMethod, matcherName) =>
       // Avoid using Jest's built-in spy since it can't be removed.
       console[consoleMethod] = consoleSpy
 
-      try {
-        callback()
-      } catch (error) {
-        caughtError = error
-      } finally {
+      const onFinally = () => {
         // Restore the unspied method so that unexpected errors fail tests.
         console[consoleMethod] = originalMethod
 
@@ -289,11 +285,56 @@ const createMatcherFor = (consoleMethod, matcherName) =>
 
         return {pass: true}
       }
+
+      let returnPromise = null
+      try {
+        const result = callback()
+
+        if (
+          typeof result === 'object' &&
+          result !== null &&
+          typeof result.then === 'function'
+        ) {
+          // `act` returns a thenable that can't be chained.
+          // Once `act(async () => {}).then(() => {}).then(() => {})` works
+          // we can just return `result.then(onFinally, error => ...)`
+          returnPromise = new Promise((resolve, reject) => {
+            result
+              .then(
+                () => {
+                  resolve(onFinally())
+                },
+                error => {
+                  caughtError = error
+                  return resolve(onFinally())
+                },
+              )
+              // In case onFinally throws we need to reject from this matcher
+              .catch(error => {
+                reject(error)
+              })
+          })
+        }
+      } catch (error) {
+        caughtError = error
+      } finally {
+        return returnPromise === null ? onFinally() : returnPromise
+      }
     } else {
       // Any uncaught errors or warnings should fail tests in production mode.
-      callback()
+      const result = callback()
 
-      return {pass: true}
+      if (
+        typeof result === 'object' &&
+        result !== null &&
+        typeof result.then === 'function'
+      ) {
+        return result.then(() => {
+          return {pass: true}
+        })
+      } else {
+        return {pass: true}
+      }
     }
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,12 +6,9 @@ import {
   BoundFunction,
   prettyFormat,
   Config as ConfigDTL,
+  FireFunction as DTLFireFunction,
+  FireObject as DTLFireObject,
 } from '@testing-library/dom'
-import {act as reactDeprecatedAct} from 'react-dom/test-utils'
-//@ts-ignore
-import {act as reactAct} from 'react'
-
-export * from '@testing-library/dom'
 
 export interface Config extends ConfigDTL {
   reactStrictMode: boolean
@@ -24,6 +21,20 @@ export interface ConfigFn {
 export function configure(configDelta: ConfigFn | Partial<Config>): void
 
 export function getConfig(): Config
+
+export * from '@testing-library/dom'
+
+export type FireFunction = (
+  ...parameters: Parameters<DTLFireFunction>
+) => Promise<ReturnType<DTLFireFunction>>
+
+export type FireObject = {
+  [K in keyof DTLFireObject]: (
+    ...parameters: Parameters<DTLFireObject[K]>
+  ) => Promise<ReturnType<DTLFireObject[K]>>
+}
+
+export const fireEvent: FireFunction & FireObject
 
 export type RenderResult<
   Q extends Queries = typeof queries,
@@ -41,8 +52,8 @@ export type RenderResult<
     maxLength?: number | undefined,
     options?: prettyFormat.OptionsReceived | undefined,
   ) => void
-  rerender: (ui: React.ReactNode) => void
-  unmount: () => void
+  rerender: (ui: React.ReactNode) => Promise<void>
+  unmount: () => Promise<void>
   asFragment: () => DocumentFragment
 } & {[P in keyof Q]: BoundFunction<Q[P]>}
 
@@ -175,17 +186,17 @@ export function render<
 >(
   ui: React.ReactNode,
   options: RenderOptions<Q, Container, BaseElement>,
-): RenderResult<Q, Container, BaseElement>
+): Promise<RenderResult<Q, Container, BaseElement>>
 export function render(
   ui: React.ReactNode,
   options?: Omit<RenderOptions, 'queries'> | undefined,
-): RenderResult
+): Promise<RenderResult>
 
 export interface RenderHookResult<Result, Props> {
   /**
    * Triggers a re-render. The props will be passed to your renderHook callback.
    */
-  rerender: (props?: Props) => void
+  rerender: (props?: Props) => Promise<void>
   /**
    * This is a stable reference to the latest value returned by your renderHook
    * callback
@@ -200,7 +211,7 @@ export interface RenderHookResult<Result, Props> {
    * Unmounts the test component. This is useful for when you need to test
    * any cleanup your useEffects have.
    */
-  unmount: () => void
+  unmount: () => Promise<void>
 }
 
 /** @deprecated */
@@ -269,19 +280,14 @@ export function renderHook<
 >(
   render: (initialProps: Props) => Result,
   options?: RenderHookOptions<Props, Q, Container, BaseElement> | undefined,
-): RenderHookResult<Result, Props>
+): Promise<RenderHookResult<Result, Props>>
 
 /**
  * Unmounts React trees that were mounted with render.
  */
-export function cleanup(): void
+export function cleanup(): Promise<void>
 
 /**
- * Simply calls React.act(cb)
- * If that's not available (older version of react) then it
- * simply calls the deprecated version which is ReactTestUtils.act(cb)
+ * `act` for the DOM renderer
  */
-// IfAny<typeof reactAct, reactDeprecatedAct, reactAct> from https://stackoverflow.com/a/61626123/3406963
-export const act: 0 extends 1 & typeof reactAct
-  ? typeof reactDeprecatedAct
-  : typeof reactAct
+export function act<T>(scope: () => T | Promise<T>): Promise<T>

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
-import {render, fireEvent, screen, waitFor, renderHook} from '.'
+import {act, render, fireEvent, screen, waitFor, renderHook} from '.'
 import * as pure from './pure'
 
 export async function testRender() {
-  const view = render(<button />)
+  const view = await render(<button />)
 
   // single queries
   view.getByText('foo')
@@ -22,7 +22,7 @@ export async function testRender() {
 }
 
 export async function testPureRender() {
-  const view = pure.render(<button />)
+  const view = await pure.render(<button />)
 
   // single queries
   view.getByText('foo')
@@ -40,28 +40,28 @@ export async function testPureRender() {
   return {container, rerender, debug}
 }
 
-export function testRenderOptions() {
+export async function testRenderOptions() {
   const container = document.createElement('div')
   const options = {container}
-  const {container: returnedContainer} = render(<button />, options)
+  const {container: returnedContainer} = await render(<button />, options)
   expectType<HTMLDivElement, typeof returnedContainer>(returnedContainer)
 
-  render(<div />, {wrapper: () => null})
+  await render(<div />, {wrapper: () => null})
 }
 
-export function testSVGRenderOptions() {
+export async function testSVGRenderOptions() {
   const container = document.createElementNS(
     'http://www.w3.org/2000/svg',
     'svg',
   )
   const options = {container}
-  const {container: returnedContainer} = render(<path />, options)
+  const {container: returnedContainer} = await render(<path />, options)
   expectType<SVGSVGElement, typeof returnedContainer>(returnedContainer)
 }
 
-export function testFireEvent() {
-  const {container} = render(<button />)
-  fireEvent.click(container)
+export async function testFireEvent() {
+  const {container} = await render(<button />)
+  await fireEvent.click(container)
 }
 
 export function testConfigure() {
@@ -86,8 +86,8 @@ export function testGetConfig() {
   pure.getConfig().reactStrictMode
 }
 
-export function testDebug() {
-  const {debug, getAllByTestId} = render(
+export async function testDebug() {
+  const {debug, getAllByTestId} = await render(
     <>
       <h2 data-testid="testid">Hello World</h2>
       <h2 data-testid="testid">Hello World</h2>
@@ -97,19 +97,19 @@ export function testDebug() {
 }
 
 export async function testScreen() {
-  render(<button />)
+  await render(<button />)
 
   await screen.findByRole('button')
 }
 
 export async function testWaitFor() {
-  const {container} = render(<button />)
-  fireEvent.click(container)
+  const {container} = await render(<button />)
+  await fireEvent.click(container)
   await waitFor(() => {})
 }
 
-export function testQueries() {
-  const {getByLabelText} = render(
+export async function testQueries() {
+  const {getByLabelText} = await render(
     <label htmlFor="usernameInput">Username</label>,
   )
   expectType<HTMLElement, ReturnType<typeof getByLabelText>>(
@@ -118,7 +118,7 @@ export function testQueries() {
 
   const container = document.createElement('div')
   const options = {container}
-  const {getByText} = render(<div>Hello World</div>, options)
+  const {getByText} = await render(<div>Hello World</div>, options)
   expectType<HTMLElement, ReturnType<typeof getByText>>(
     getByText('Hello World'),
   )
@@ -193,18 +193,20 @@ export function wrappedRenderHook<Props>(
   return pure.renderHook(hook, {...options})
 }
 
-export function testBaseElement() {
-  const {baseElement: baseDefaultElement} = render(<div />)
+export async function testBaseElement() {
+  const {baseElement: baseDefaultElement} = await render(<div />)
   expectType<HTMLElement, typeof baseDefaultElement>(baseDefaultElement)
 
   const container = document.createElement('input')
-  const {baseElement: baseElementFromContainer} = render(<div />, {container})
+  const {baseElement: baseElementFromContainer} = await render(<div />, {
+    container,
+  })
   expectType<typeof container, typeof baseElementFromContainer>(
     baseElementFromContainer,
   )
 
   const baseElementOption = document.createElement('input')
-  const {baseElement: baseElementFromOption} = render(<div />, {
+  const {baseElement: baseElementFromOption} = await render(<div />, {
     baseElement: baseElementOption,
   })
   expectType<typeof baseElementOption, typeof baseElementFromOption>(
@@ -212,77 +214,93 @@ export function testBaseElement() {
   )
 }
 
-export function testRenderHook() {
-  const {result, rerender, unmount} = renderHook(() => React.useState(2)[0])
+export async function testRenderHook() {
+  const {result, rerender, unmount} = await renderHook(
+    () => React.useState(2)[0],
+  )
 
   expectType<number, typeof result.current>(result.current)
 
-  rerender()
+  await rerender()
 
-  unmount()
+  await unmount()
 
-  renderHook(() => null, {wrapper: () => null})
+  await renderHook(() => null, {wrapper: () => null})
 }
 
-export function testRenderHookProps() {
-  const {result, rerender, unmount} = renderHook(
+export async function testRenderHookProps() {
+  const {result, rerender, unmount} = await renderHook(
     ({defaultValue}) => React.useState(defaultValue)[0],
     {initialProps: {defaultValue: 2}},
   )
 
   expectType<number, typeof result.current>(result.current)
 
-  rerender()
+  await rerender()
 
-  unmount()
+  await unmount()
 }
 
-export function testContainer() {
-  render('a', {container: document.createElement('div')})
-  render('a', {container: document.createDocumentFragment()})
+export async function testContainer() {
+  await render('a', {container: document.createElement('div')})
+  await render('a', {container: document.createDocumentFragment()})
   //  Only allowed in React 19
-  render('a', {container: document})
-  render('a', {container: document.createElement('div'), hydrate: true})
+  await render('a', {container: document})
+  await render('a', {container: document.createElement('div'), hydrate: true})
   // Only allowed for createRoot but typing `render` appropriately makes it harder to compose.
-  render('a', {container: document.createDocumentFragment(), hydrate: true})
-  render('a', {container: document, hydrate: true})
+  await render('a', {
+    container: document.createDocumentFragment(),
+    hydrate: true,
+  })
+  await render('a', {container: document, hydrate: true})
 
-  renderHook(() => null, {container: document.createElement('div')})
-  renderHook(() => null, {container: document.createDocumentFragment()})
+  await renderHook(() => null, {container: document.createElement('div')})
+  await renderHook(() => null, {container: document.createDocumentFragment()})
   //  Only allowed in React 19
-  renderHook(() => null, {container: document})
-  renderHook(() => null, {
+  await renderHook(() => null, {container: document})
+  await renderHook(() => null, {
     container: document.createElement('div'),
     hydrate: true,
   })
   // Only allowed for createRoot but typing `render` appropriately makes it harder to compose.
-  renderHook(() => null, {
+  await renderHook(() => null, {
     container: document.createDocumentFragment(),
     hydrate: true,
   })
-  renderHook(() => null, {container: document, hydrate: true})
+  await renderHook(() => null, {container: document, hydrate: true})
 }
 
-export function testErrorHandlers() {
+export async function testErrorHandlers() {
   // React 19 types are not used in tests. Verify manually if this works with `"@types/react": "npm:types-react@rc"`
-  render(null, {
+  await render(null, {
     // Should work with React 19 types
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     onCaughtError: () => {},
   })
-  render(null, {
+  await render(null, {
     // Should never work as it's not supported yet.
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     onUncaughtError: () => {},
   })
-  render(null, {
+  await render(null, {
     onRecoverableError: (error, errorInfo) => {
       console.error(error)
       console.log(errorInfo.componentStack)
     },
   })
+}
+
+export async function actTest() {
+  function actWrapper<T>(scope: () => T | Promise<T>): Promise<T> {
+    return act(async () => {
+      return scope()
+    })
+  }
+
+  await actWrapper(() => {})
+  await actWrapper(async () => {})
 }
 
 /*


### PR DESCRIPTION
Will be released in the next alpha to test at Meta and Vercel first.

**BREAKING CHANGE**

`act` and APIs using it (e.g. `render` or `renderHook`) are now async and must be awaited. 
This change can be codemodded with https://github.com/eps1lon/codemod-missing-await-act. Current version of `user-event` is not compatible yet until `user-event` awaits all calls to `eventWrapper`.

Requires https://github.com/testing-library/dom-testing-library/pull/1369

follow-up:

- [ ] update reference docs (and write FAQ for "How to test loading states"

## fixes to missing act warnings

Sometimes you wanted to assert on a given commit of the component without caring about scheduled tasks. This always worked since these scheduled tasks were on the macrotask queue (e.g. `setTimeout`) because we automatically unmounted the component after the test ended.
However, when these tasks where on the microtasks queue (e.g. a promise that just resolved), you would get a missing act warning between the test ending and our automatic cleanup running. 

The only solution would've been to add an explicit unmount to **each** test.

Now that we require `await act(...)` these issues will no longer persist since we'll also flush the state updates on the microtask queue. If you want to continue asserting on the intermediate states, you can use `globalThis.IS_REACT_ACT_ENVIRONMENT = false`. Keep in mind though that while this flag is set, you have to manually wait for every state update to be applied e.g. by using `findBy` or `waitFor`.

## Timer changes after module initialization

Drops support for changing timers after module initialization.
This affects tests that changed the timer implementation (i.e. fake vs real timers) after modules were imported. For example, in the following test, updates are no longer flushed.

```tsx
import { render, screen } from "@testing-library/react";
import { useState } from "react";

jest.useFakeTimers;

test("updates", async () => {
  function Component() {
    const [state, setState] = useState("initial");
    useEffect(() => {
      const timeoutID = setTimeout(() => {
        setState("committed");
      }, 50);

      return () => {
        clearTimeout(timeoutID);
      };
    }, []);
    return state;
  }
  const { container } = await render(<Component />);

  // will timeout
  await waitFor(() => {
    expect(container.textContent).toEqual("committed");
  });
});
```

Instead, you have to decide on timers **before** you import modules. In Jest, you can choose timers at the config level, or keep using `jest.useFaketimers()` but call it before any `import` or `require`.

This only ever worked because we cheated a bit and flipped silently to an act environment during `waitFor`. However, since we now flush a bit more when using `IS_REACT_ACT_ENVIRONMENT`, we need to offer APIs to assert on intermediate states e.g. when your component initially displays a loading spinner that goes away in the next microtask. You can do this by simply setting `globalThis.IS_REACT_ACT_ENVIRONMENT = false` and continue to use existing APIs. React will fallback to standard (real or fake) timers and not the act queue.


Fixes https://github.com/testing-library/react-testing-library/issues/1385