### PR TITLE
test: Add test for flushing before exiting `waitFor`

### DIFF
--- a/src/__tests__/end-to-end.js
+++ b/src/__tests__/end-to-end.js
@@ -2,8 +2,8 @@ import * as React from 'react'
 import {render, waitForElementToBeRemoved, screen, waitFor} from '../'
 
 describe.each([
-  ['real timers', () => jest.useRealTimers()],
-  ['fake legacy timers', () => jest.useFakeTimers('legacy')],
+  // ['real timers', () => jest.useRealTimers()],
+  // ['fake legacy timers', () => jest.useFakeTimers('legacy')],
   ['fake modern timers', () => jest.useFakeTimers('modern')],
 ])(
   'it waits for the data to be loaded in a macrotask using %s',
@@ -80,7 +80,7 @@ describe.each([
   ['fake legacy timers', () => jest.useFakeTimers('legacy')],
   ['fake modern timers', () => jest.useFakeTimers('modern')],
 ])(
-  'it waits for the data to be loaded in a microtask using %s',
+  'it waits for the data to be loaded in many microtask using %s',
   (label, useTimers) => {
     beforeEach(() => {
       useTimers()
@@ -123,6 +123,76 @@ describe.each([
                   setFetchState({todo: data.title, fetching: false})
                 })
             )
+          })
+        }
+      }, [fetchState])
+
+      if (fetchState.fetching) {
+        return <p>Loading..</p>
+      }
+
+      return (
+        <div data-testid="message">Loaded this message: {fetchState.todo}</div>
+      )
+    }
+
+    test('waitForElementToBeRemoved', async () => {
+      render(<ComponentWithMicrotaskLoader />)
+      const loading = () => screen.getByText('Loading..')
+      await waitForElementToBeRemoved(loading)
+      expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
+    })
+
+    test('waitFor', async () => {
+      render(<ComponentWithMicrotaskLoader />)
+      await waitFor(() => {
+        screen.getByText('Loading..')
+      })
+      await waitFor(() => {
+        screen.getByText(/Loaded this message:/)
+      })
+      expect(screen.getByTestId('message')).toHaveTextContent(/Hello World/)
+    })
+
+    test('findBy', async () => {
+      render(<ComponentWithMicrotaskLoader />)
+      await expect(screen.findByTestId('message')).resolves.toHaveTextContent(
+        /Hello World/,
+      )
+    })
+  },
+)
+
+describe.each([
+  ['real timers', () => jest.useRealTimers()],
+  ['fake legacy timers', () => jest.useFakeTimers('legacy')],
+  ['fake modern timers', () => jest.useFakeTimers('modern')],
+])(
+  'it waits for the data to be loaded in a microtask using %s',
+  (label, useTimers) => {
+    beforeEach(() => {
+      useTimers()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    const fetchAMessageInAMicrotask = () =>
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve({title: 'Hello World'}),
+      })
+
+    function ComponentWithMicrotaskLoader() {
+      const [fetchState, setFetchState] = React.useState({fetching: true})
+
+      React.useEffect(() => {
+        if (fetchState.fetching) {
+          fetchAMessageInAMicrotask().then(res => {
+            return res.json().then(data => {
+              setFetchState({todo: data.title, fetching: false})
+            })
           })
         }
       }, [fetchState])

--- a/src/__tests__/end-to-end.js
+++ b/src/__tests__/end-to-end.js
@@ -2,8 +2,8 @@ import * as React from 'react'
 import {render, waitForElementToBeRemoved, screen, waitFor} from '../'
 
 describe.each([
-  // ['real timers', () => jest.useRealTimers()],
-  // ['fake legacy timers', () => jest.useFakeTimers('legacy')],
+  ['real timers', () => jest.useRealTimers()],
+  ['fake legacy timers', () => jest.useFakeTimers('legacy')],
   ['fake modern timers', () => jest.useFakeTimers('modern')],
 ])(
   'it waits for the data to be loaded in a macrotask using %s',

--- a/src/pure.js
+++ b/src/pure.js
@@ -12,6 +12,20 @@ import act, {
 } from './act-compat'
 import {fireEvent} from './fire-event'
 
+function jestFakeTimersAreEnabled() {
+  /* istanbul ignore else */
+  if (typeof jest !== 'undefined' && jest !== null) {
+    return (
+      // legacy timers
+      setTimeout._isMockFunction === true || // modern timers
+      // eslint-disable-next-line prefer-object-has-own -- No Object.hasOwn in all target environments we support.
+      Object.prototype.hasOwnProperty.call(setTimeout, 'clock')
+    )
+  } // istanbul ignore next
+
+  return false
+}
+
 configureDTL({
   unstable_advanceTimersWrapper: cb => {
     return act(cb)
@@ -23,7 +37,21 @@ configureDTL({
     const previousActEnvironment = getIsReactActEnvironment()
     setReactActEnvironment(false)
     try {
-      return await cb()
+      const result = await cb()
+      // Drain microtask queue.
+      // Otherwise we'll restore the previous act() environment, before we resolve the `waitFor` call.
+      // The caller would have no chance to wrap the in-flight Promises in `act()`
+      await new Promise(resolve => {
+        setTimeout(() => {
+          resolve()
+        }, 0)
+
+        if (jestFakeTimersAreEnabled()) {
+          jest.advanceTimersByTime(0)
+        }
+      })
+
+      return result
     } finally {
       setReactActEnvironment(previousActEnvironment)
     }

--- a/src/pure.js
+++ b/src/pure.js
@@ -12,20 +12,6 @@ import act, {
 } from './act-compat'
 import {fireEvent} from './fire-event'
 
-function jestFakeTimersAreEnabled() {
-  /* istanbul ignore else */
-  if (typeof jest !== 'undefined' && jest !== null) {
-    return (
-      // legacy timers
-      setTimeout._isMockFunction === true || // modern timers
-      // eslint-disable-next-line prefer-object-has-own -- No Object.hasOwn in all target environments we support.
-      Object.prototype.hasOwnProperty.call(setTimeout, 'clock')
-    )
-  } // istanbul ignore next
-
-  return false
-}
-
 configureDTL({
   unstable_advanceTimersWrapper: cb => {
     return act(cb)
@@ -37,21 +23,7 @@ configureDTL({
     const previousActEnvironment = getIsReactActEnvironment()
     setReactActEnvironment(false)
     try {
-      const result = await cb()
-      // Drain microtask queue.
-      // Otherwise we'll restore the previous act() environment, before we resolve the `waitFor` call.
-      // The caller would have no chance to wrap the in-flight Promises in `act()`
-      await new Promise(resolve => {
-        setTimeout(() => {
-          resolve()
-        }, 0)
-
-        if (jestFakeTimersAreEnabled()) {
-          jest.advanceTimersByTime(0)
-        }
-      })
-
-      return result
+      return await cb()
     } finally {
       setReactActEnvironment(previousActEnvironment)
     }


### PR DESCRIPTION
Tests in https://github.com/testing-library/react-testing-library/pull/1137 didn't actually show why we need it.

New tests fail without https://github.com/testing-library/react-testing-library/pull/1137 (https://github.com/testing-library/react-testing-library/actions/runs/5047921618/jobs/9055439894?pr=1215) but pass with latest code.