### PR TITLE
docs(readme): remove deprecated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,9 +376,6 @@ Some included are:
 - [`react-router`](https://codesandbox.io/s/github/kentcdodds/react-testing-library-examples/tree/main/?fontsize=14&module=%2Fsrc%2F__tests__%2Freact-router.js&previewwindow=tests)
 - [`react-context`](https://codesandbox.io/s/github/kentcdodds/react-testing-library-examples/tree/main/?fontsize=14&module=%2Fsrc%2F__tests__%2Freact-context.js&previewwindow=tests)
 
-You can also find React Testing Library examples at
-[react-testing-examples.com](https://react-testing-examples.com/jest-rtl/).
-
 ## Hooks
 
 If you are interested in testing a custom hook, check out [React Hooks Testing


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Resolves #1228

<!-- Why are these changes necessary? -->

**Why**: The linked site is no longer available.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
