### PR TITLE
feat: add `reactStrictMode` option to enable strict mode render

### DIFF
--- a/src/__tests__/__snapshots__/render.js.snap
+++ b/src/__tests__/__snapshots__/render.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`supports fragments 1`] = `
+exports[`render API supports fragments 1`] = `
 <DocumentFragment>
   <div>
     <code>

--- a/src/__tests__/config.js
+++ b/src/__tests__/config.js
@@ -1,0 +1,66 @@
+import {configure, getConfig} from '../'
+
+describe('configuration API', () => {
+  let originalConfig
+  beforeEach(() => {
+    // Grab the existing configuration so we can restore
+    // it at the end of the test
+    configure(existingConfig => {
+      originalConfig = existingConfig
+      // Don't change the existing config
+      return {}
+    })
+  })
+
+  afterEach(() => {
+    configure(originalConfig)
+  })
+
+  describe('DTL options', () => {
+    test('configure can set by a plain JS object', () => {
+      const testIdAttribute = 'not-data-testid'
+      configure({testIdAttribute})
+
+      expect(getConfig().testIdAttribute).toBe(testIdAttribute)
+    })
+
+    test('configure can set by a function', () => {
+      // setup base option
+      const baseTestIdAttribute = 'data-testid'
+      configure({testIdAttribute: baseTestIdAttribute})
+
+      const modifiedPrefix = 'modified-'
+      configure(existingConfig => ({
+        testIdAttribute: `${modifiedPrefix}${existingConfig.testIdAttribute}`,
+      }))
+
+      expect(getConfig().testIdAttribute).toBe(
+        `${modifiedPrefix}${baseTestIdAttribute}`,
+      )
+    })
+  })
+
+  describe('RTL options', () => {
+    test('configure can set by a plain JS object', () => {
+      configure({reactStrictMode: true})
+
+      expect(getConfig().reactStrictMode).toBe(true)
+    })
+
+    test('configure can set by a function', () => {
+      configure(existingConfig => ({
+        reactStrictMode: !existingConfig.reactStrictMode,
+      }))
+
+      expect(getConfig().reactStrictMode).toBe(true)
+    })
+  })
+
+  test('configure can set DTL and RTL options at once', () => {
+    const testIdAttribute = 'not-data-testid'
+    configure({testIdAttribute, reactStrictMode: true})
+
+    expect(getConfig().testIdAttribute).toBe(testIdAttribute)
+    expect(getConfig().reactStrictMode).toBe(true)
+  })
+})

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -1,84 +1,100 @@
 import * as React from 'react'
 import ReactDOM from 'react-dom'
 import ReactDOMServer from 'react-dom/server'
-import {fireEvent, render, screen} from '../'
+import {fireEvent, render, screen, configure} from '../'
 
-test('renders div into document', () => {
-  const ref = React.createRef()
-  const {container} = render(<div ref={ref} />)
-  expect(container.firstChild).toBe(ref.current)
-})
+describe('render API', () => {
+  let originalConfig
+  beforeEach(() => {
+    // Grab the existing configuration so we can restore
+    // it at the end of the test
+    configure(existingConfig => {
+      originalConfig = existingConfig
+      // Don't change the existing config
+      return {}
+    })
+  })
 
-test('works great with react portals', () => {
-  class MyPortal extends React.Component {
-    constructor(...args) {
-      super(...args)
-      this.portalNode = document.createElement('div')
-      this.portalNode.dataset.testid = 'my-portal'
+  afterEach(() => {
+    configure(originalConfig)
+  })
+
+  test('renders div into document', () => {
+    const ref = React.createRef()
+    const {container} = render(<div ref={ref} />)
+    expect(container.firstChild).toBe(ref.current)
+  })
+
+  test('works great with react portals', () => {
+    class MyPortal extends React.Component {
+      constructor(...args) {
+        super(...args)
+        this.portalNode = document.createElement('div')
+        this.portalNode.dataset.testid = 'my-portal'
+      }
+      componentDidMount() {
+        document.body.appendChild(this.portalNode)
+      }
+      componentWillUnmount() {
+        this.portalNode.parentNode.removeChild(this.portalNode)
+      }
+      render() {
+        return ReactDOM.createPortal(
+          <Greet greeting="Hello" subject="World" />,
+          this.portalNode,
+        )
+      }
     }
-    componentDidMount() {
-      document.body.appendChild(this.portalNode)
-    }
-    componentWillUnmount() {
-      this.portalNode.parentNode.removeChild(this.portalNode)
-    }
-    render() {
-      return ReactDOM.createPortal(
-        <Greet greeting="Hello" subject="World" />,
-        this.portalNode,
-      )
-    }
-  }
 
-  function Greet({greeting, subject}) {
-    return (
-      <div>
-        <strong>
-          {greeting} {subject}
-        </strong>
-      </div>
-    )
-  }
-
-  const {unmount} = render(<MyPortal />)
-  expect(screen.getByText('Hello World')).toBeInTheDocument()
-  const portalNode = screen.getByTestId('my-portal')
-  expect(portalNode).toBeInTheDocument()
-  unmount()
-  expect(portalNode).not.toBeInTheDocument()
-})
-
-test('returns baseElement which defaults to document.body', () => {
-  const {baseElement} = render(<div />)
-  expect(baseElement).toBe(document.body)
-})
-
-test('supports fragments', () => {
-  class Test extends React.Component {
-    render() {
+    function Greet({greeting, subject}) {
       return (
         <div>
-          <code>DocumentFragment</code> is pretty cool!
+          <strong>
+            {greeting} {subject}
+          </strong>
         </div>
       )
     }
-  }
 
-  const {asFragment} = render(<Test />)
-  expect(asFragment()).toMatchSnapshot()
-})
-
-test('renders options.wrapper around node', () => {
-  const WrapperComponent = ({children}) => (
-    <div data-testid="wrapper">{children}</div>
-  )
-
-  const {container} = render(<div data-testid="inner" />, {
-    wrapper: WrapperComponent,
+    const {unmount} = render(<MyPortal />)
+    expect(screen.getByText('Hello World')).toBeInTheDocument()
+    const portalNode = screen.getByTestId('my-portal')
+    expect(portalNode).toBeInTheDocument()
+    unmount()
+    expect(portalNode).not.toBeInTheDocument()
   })
 
-  expect(screen.getByTestId('wrapper')).toBeInTheDocument()
-  expect(container.firstChild).toMatchInlineSnapshot(`
+  test('returns baseElement which defaults to document.body', () => {
+    const {baseElement} = render(<div />)
+    expect(baseElement).toBe(document.body)
+  })
+
+  test('supports fragments', () => {
+    class Test extends React.Component {
+      render() {
+        return (
+          <div>
+            <code>DocumentFragment</code> is pretty cool!
+          </div>
+        )
+      }
+    }
+
+    const {asFragment} = render(<Test />)
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('renders options.wrapper around node', () => {
+    const WrapperComponent = ({children}) => (
+      <div data-testid="wrapper">{children}</div>
+    )
+
+    const {container} = render(<div data-testid="inner" />, {
+      wrapper: WrapperComponent,
+    })
+
+    expect(screen.getByTestId('wrapper')).toBeInTheDocument()
+    expect(container.firstChild).toMatchInlineSnapshot(`
     <div
       data-testid=wrapper
     >
@@ -87,102 +103,138 @@ test('renders options.wrapper around node', () => {
       />
     </div>
   `)
-})
+  })
 
-test('flushes useEffect cleanup functions sync on unmount()', () => {
-  const spy = jest.fn()
-  function Component() {
-    React.useEffect(() => spy, [])
-    return null
-  }
-  const {unmount} = render(<Component />)
-  expect(spy).toHaveBeenCalledTimes(0)
+  test('renders options.wrapper around node when reactStrictMode is true', () => {
+    configure({reactStrictMode: true})
 
-  unmount()
-
-  expect(spy).toHaveBeenCalledTimes(1)
-})
-
-test('can be called multiple times on the same container', () => {
-  const container = document.createElement('div')
-
-  const {unmount} = render(<strong />, {container})
-
-  expect(container).toContainHTML('<strong></strong>')
-
-  render(<em />, {container})
-
-  expect(container).toContainHTML('<em></em>')
-
-  unmount()
-
-  expect(container).toBeEmptyDOMElement()
-})
-
-test('hydrate will make the UI interactive', () => {
-  function App() {
-    const [clicked, handleClick] = React.useReducer(n => n + 1, 0)
-
-    return (
-      <button type="button" onClick={handleClick}>
-        clicked:{clicked}
-      </button>
+    const WrapperComponent = ({children}) => (
+      <div data-testid="wrapper">{children}</div>
     )
-  }
-  const ui = <App />
-  const container = document.createElement('div')
-  document.body.appendChild(container)
-  container.innerHTML = ReactDOMServer.renderToString(ui)
-
-  expect(container).toHaveTextContent('clicked:0')
-
-  render(ui, {container, hydrate: true})
-
-  fireEvent.click(container.querySelector('button'))
-
-  expect(container).toHaveTextContent('clicked:1')
-})
-
-test('hydrate can have a wrapper', () => {
-  const wrapperComponentMountEffect = jest.fn()
-  function WrapperComponent({children}) {
-    React.useEffect(() => {
-      wrapperComponentMountEffect()
+    const {container} = render(<div data-testid="inner" />, {
+      wrapper: WrapperComponent,
     })
 
-    return children
-  }
-  const ui = <div />
-  const container = document.createElement('div')
-  document.body.appendChild(container)
-  container.innerHTML = ReactDOMServer.renderToString(ui)
+    expect(screen.getByTestId('wrapper')).toBeInTheDocument()
+    expect(container.firstChild).toMatchInlineSnapshot(`
+    <div
+      data-testid=wrapper
+    >
+      <div
+        data-testid=inner
+      />
+    </div>
+  `)
+  })
 
-  render(ui, {container, hydrate: true, wrapper: WrapperComponent})
+  test('renders twice when reactStrictMode is true', () => {
+    configure({reactStrictMode: true})
 
-  expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(1)
-})
+    const spy = jest.fn()
+    function Component() {
+      spy()
+      return null
+    }
 
-test('legacyRoot uses legacy ReactDOM.render', () => {
-  expect(() => {
-    render(<div />, {legacyRoot: true})
-  }).toErrorDev(
-    [
-      "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-    ],
-    {withoutStack: true},
-  )
-})
+    render(<Component />)
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
 
-test('legacyRoot uses legacy ReactDOM.hydrate', () => {
-  const ui = <div />
-  const container = document.createElement('div')
-  container.innerHTML = ReactDOMServer.renderToString(ui)
-  expect(() => {
-    render(ui, {container, hydrate: true, legacyRoot: true})
-  }).toErrorDev(
-    [
-      "Warning: ReactDOM.hydrate is no longer supported in React 18. Use hydrateRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-    ],
-    {withoutStack: true},
-  )
+  test('flushes useEffect cleanup functions sync on unmount()', () => {
+    const spy = jest.fn()
+    function Component() {
+      React.useEffect(() => spy, [])
+      return null
+    }
+    const {unmount} = render(<Component />)
+    expect(spy).toHaveBeenCalledTimes(0)
+
+    unmount()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  test('can be called multiple times on the same container', () => {
+    const container = document.createElement('div')
+
+    const {unmount} = render(<strong />, {container})
+
+    expect(container).toContainHTML('<strong></strong>')
+
+    render(<em />, {container})
+
+    expect(container).toContainHTML('<em></em>')
+
+    unmount()
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  test('hydrate will make the UI interactive', () => {
+    function App() {
+      const [clicked, handleClick] = React.useReducer(n => n + 1, 0)
+
+      return (
+        <button type="button" onClick={handleClick}>
+          clicked:{clicked}
+        </button>
+      )
+    }
+    const ui = <App />
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    container.innerHTML = ReactDOMServer.renderToString(ui)
+
+    expect(container).toHaveTextContent('clicked:0')
+
+    render(ui, {container, hydrate: true})
+
+    fireEvent.click(container.querySelector('button'))
+
+    expect(container).toHaveTextContent('clicked:1')
+  })
+
+  test('hydrate can have a wrapper', () => {
+    const wrapperComponentMountEffect = jest.fn()
+    function WrapperComponent({children}) {
+      React.useEffect(() => {
+        wrapperComponentMountEffect()
+      })
+
+      return children
+    }
+    const ui = <div />
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    container.innerHTML = ReactDOMServer.renderToString(ui)
+
+    render(ui, {container, hydrate: true, wrapper: WrapperComponent})
+
+    expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(1)
+  })
+
+  test('legacyRoot uses legacy ReactDOM.render', () => {
+    expect(() => {
+      render(<div />, {legacyRoot: true})
+    }).toErrorDev(
+      [
+        "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
+      ],
+      {withoutStack: true},
+    )
+  })
+
+  test('legacyRoot uses legacy ReactDOM.hydrate', () => {
+    const ui = <div />
+    const container = document.createElement('div')
+    container.innerHTML = ReactDOMServer.renderToString(ui)
+    expect(() => {
+      render(ui, {container, hydrate: true, legacyRoot: true})
+    }).toErrorDev(
+      [
+        "Warning: ReactDOM.hydrate is no longer supported in React 18. Use hydrateRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
+      ],
+      {withoutStack: true},
+    )
+  })
 })

--- a/src/__tests__/rerender.js
+++ b/src/__tests__/rerender.js
@@ -1,31 +1,98 @@
 import * as React from 'react'
-import {render} from '../'
+import {render, configure} from '../'
 
-test('rerender will re-render the element', () => {
-  const Greeting = props => <div>{props.message}</div>
-  const {container, rerender} = render(<Greeting message="hi" />)
-  expect(container.firstChild).toHaveTextContent('hi')
-  rerender(<Greeting message="hey" />)
-  expect(container.firstChild).toHaveTextContent('hey')
-})
-
-test('hydrate will not update props until next render', () => {
-  const initialInputElement = document.createElement('input')
-  const container = document.createElement('div')
-  container.appendChild(initialInputElement)
-  document.body.appendChild(container)
-
-  const firstValue = 'hello'
-  initialInputElement.value = firstValue
-
-  const {rerender} = render(<input value="" onChange={() => null} />, {
-    container,
-    hydrate: true,
+describe('rerender API', () => {
+  let originalConfig
+  beforeEach(() => {
+    // Grab the existing configuration so we can restore
+    // it at the end of the test
+    configure(existingConfig => {
+      originalConfig = existingConfig
+      // Don't change the existing config
+      return {}
+    })
   })
 
-  expect(initialInputElement).toHaveValue(firstValue)
+  afterEach(() => {
+    configure(originalConfig)
+  })
 
-  const secondValue = 'goodbye'
-  rerender(<input value={secondValue} onChange={() => null} />)
-  expect(initialInputElement).toHaveValue(secondValue)
+  test('rerender will re-render the element', () => {
+    const Greeting = props => <div>{props.message}</div>
+    const {container, rerender} = render(<Greeting message="hi" />)
+    expect(container.firstChild).toHaveTextContent('hi')
+    rerender(<Greeting message="hey" />)
+    expect(container.firstChild).toHaveTextContent('hey')
+  })
+
+  test('hydrate will not update props until next render', () => {
+    const initialInputElement = document.createElement('input')
+    const container = document.createElement('div')
+    container.appendChild(initialInputElement)
+    document.body.appendChild(container)
+
+    const firstValue = 'hello'
+    initialInputElement.value = firstValue
+
+    const {rerender} = render(<input value="" onChange={() => null} />, {
+      container,
+      hydrate: true,
+    })
+
+    expect(initialInputElement).toHaveValue(firstValue)
+
+    const secondValue = 'goodbye'
+    rerender(<input value={secondValue} onChange={() => null} />)
+    expect(initialInputElement).toHaveValue(secondValue)
+  })
+
+  test('re-renders options.wrapper around node when reactStrictMode is true', () => {
+    configure({reactStrictMode: true})
+
+    const WrapperComponent = ({children}) => (
+      <div data-testid="wrapper">{children}</div>
+    )
+    const Greeting = props => <div>{props.message}</div>
+    const {container, rerender} = render(<Greeting message="hi" />, {
+      wrapper: WrapperComponent,
+    })
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+    <div
+      data-testid=wrapper
+    >
+      <div>
+        hi
+      </div>
+    </div>
+  `)
+
+    rerender(<Greeting message="hey" />)
+    expect(container.firstChild).toMatchInlineSnapshot(`
+    <div
+      data-testid=wrapper
+    >
+      <div>
+        hey
+      </div>
+    </div>
+  `)
+  })
+
+  test('re-renders twice when reactStrictMode is true', () => {
+    configure({reactStrictMode: true})
+
+    const spy = jest.fn()
+    function Component() {
+      spy()
+      return null
+    }
+
+    const {rerender} = render(<Component />)
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    spy.mockClear()
+    rerender(<Component />)
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,34 @@
+import {
+  getConfig as getConfigDTL,
+  configure as configureDTL,
+} from '@testing-library/dom'
+
+let configForRTL = {
+  reactStrictMode: false,
+}
+
+function getConfig() {
+  return {
+    ...getConfigDTL(),
+    ...configForRTL,
+  }
+}
+
+function configure(newConfig) {
+  if (typeof newConfig === 'function') {
+    // Pass the existing config out to the provided function
+    // and accept a delta in return
+    newConfig = newConfig(getConfig())
+  }
+
+  const {reactStrictMode, ...configForDTL} = newConfig
+
+  configureDTL(configForDTL)
+
+  configForRTL = {
+    ...configForRTL,
+    reactStrictMode,
+  }
+}
+
+export {getConfig, configure}

--- a/src/pure.js
+++ b/src/pure.js
@@ -11,6 +11,7 @@ import act, {
   setReactActEnvironment,
 } from './act-compat'
 import {fireEvent} from './fire-event'
+import {getConfig, configure} from './config'
 
 function jestFakeTimersAreEnabled() {
   /* istanbul ignore else */
@@ -276,6 +277,6 @@ function renderHook(renderCallback, options = {}) {
 
 // just re-export everything from dom-testing-library
 export * from '@testing-library/dom'
-export {render, renderHook, cleanup, act, fireEvent}
+export {render, renderHook, cleanup, act, fireEvent, getConfig, configure}
 
 /* eslint func-name-matching:0 */

--- a/src/pure.js
+++ b/src/pure.js
@@ -77,6 +77,12 @@ const mountedContainers = new Set()
  */
 const mountedRootEntries = []
 
+function strictModeIfNeeded(innerElement) {
+  return getConfig().reactStrictMode
+    ? React.createElement(React.StrictMode, null, innerElement)
+    : innerElement
+}
+
 function wrapUiIfNeeded(innerElement, wrapperComponent) {
   return wrapperComponent
     ? React.createElement(wrapperComponent, null, innerElement)
@@ -92,7 +98,7 @@ function createConcurrentRoot(
     act(() => {
       root = ReactDOMClient.hydrateRoot(
         container,
-        wrapUiIfNeeded(ui, WrapperComponent),
+        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent)),
       )
     })
   } else {
@@ -138,9 +144,15 @@ function renderRoot(
 ) {
   act(() => {
     if (hydrate) {
-      root.hydrate(wrapUiIfNeeded(ui, WrapperComponent), container)
+      root.hydrate(
+        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent)),
+        container,
+      )
     } else {
-      root.render(wrapUiIfNeeded(ui, WrapperComponent), container)
+      root.render(
+        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent)),
+        container,
+      )
     }
   })
 

--- a/src/pure.js
+++ b/src/pure.js
@@ -158,10 +158,11 @@ function renderRoot(
       })
     },
     rerender: rerenderUi => {
-      renderRoot(wrapUiIfNeeded(rerenderUi), {
+      renderRoot(rerenderUi, {
         container,
         baseElement,
         root,
+        wrapper: WrapperComponent,
       })
       // Intentionally do not return anything to avoid unnecessarily complicating the API.
       // folks can use all the same utilities we return in the first place that are bound to the container

--- a/src/pure.js
+++ b/src/pure.js
@@ -77,6 +77,12 @@ const mountedContainers = new Set()
  */
 const mountedRootEntries = []
 
+function wrapUiIfNeeded(innerElement, wrapperComponent) {
+  return wrapperComponent
+    ? React.createElement(wrapperComponent, null, innerElement)
+    : innerElement
+}
+
 function createConcurrentRoot(
   container,
   {hydrate, ui, wrapper: WrapperComponent},
@@ -86,7 +92,7 @@ function createConcurrentRoot(
     act(() => {
       root = ReactDOMClient.hydrateRoot(
         container,
-        WrapperComponent ? React.createElement(WrapperComponent, null, ui) : ui,
+        wrapUiIfNeeded(ui, WrapperComponent),
       )
     })
   } else {
@@ -130,16 +136,11 @@ function renderRoot(
   ui,
   {baseElement, container, hydrate, queries, root, wrapper: WrapperComponent},
 ) {
-  const wrapUiIfNeeded = innerElement =>
-    WrapperComponent
-      ? React.createElement(WrapperComponent, null, innerElement)
-      : innerElement
-
   act(() => {
     if (hydrate) {
-      root.hydrate(wrapUiIfNeeded(ui), container)
+      root.hydrate(wrapUiIfNeeded(ui, WrapperComponent), container)
     } else {
-      root.render(wrapUiIfNeeded(ui), container)
+      root.render(wrapUiIfNeeded(ui, WrapperComponent), container)
     }
   })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,11 +5,24 @@ import {
   Queries,
   BoundFunction,
   prettyFormat,
+  Config as ConfigDTL,
 } from '@testing-library/dom'
 import {Renderer} from 'react-dom'
 import {act as reactAct} from 'react-dom/test-utils'
 
 export * from '@testing-library/dom'
+
+export interface Config extends ConfigDTL {
+  reactStrictMode: boolean
+}
+
+export interface ConfigFn {
+  (existingConfig: Config): Partial<Config>
+}
+
+export function configure(configDelta: ConfigFn | Partial<Config>): void
+
+export function getConfig(): Config
 
 export type RenderResult<
   Q extends Queries = typeof queries,

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -62,6 +62,28 @@ export function testFireEvent() {
   fireEvent.click(container)
 }
 
+export function testConfigure() {
+  // test for DTL's config
+  pure.configure({testIdAttribute: 'foobar'})
+  pure.configure(existingConfig => ({
+    testIdAttribute: `modified-${existingConfig.testIdAttribute}`,
+  }))
+
+  // test for RTL's config
+  pure.configure({reactStrictMode: true})
+  pure.configure(existingConfig => ({
+    reactStrictMode: !existingConfig.reactStrictMode,
+  }))
+}
+
+export function testGetConfig() {
+  // test for DTL's config
+  pure.getConfig().testIdAttribute
+
+  // test for RTL's config
+  pure.getConfig().reactStrictMode
+}
+
 export function testDebug() {
   const {debug, getAllByTestId} = render(
     <>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Add `reactStrictMode` option to enable strict mode render

<!-- Why are these changes necessary? -->

**Why**:

ref: https://github.com/testing-library/react-testing-library/issues/338

<!-- How were these changes implemented? -->

**How**:

This PR updates `getConfig` and `configure` functions from DTL for handling RTL options (e.g. `reactStrictMode`).
This PR also wraps UI in `render` function with `React.StrictMode` component when `reactStrictMode` is true.
By default, `reactStrictMode` is false. (according to https://github.com/testing-library/react-testing-library/issues/338)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) -> https://github.com/testing-library/testing-library-docs/pull/1318
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
