### PR TITLE
refac: Add a dependency array for useEffect

### DIFF
--- a/src/__tests__/act.js
+++ b/src/__tests__/act.js
@@ -20,8 +20,8 @@ test('findByTestId returns the element', async () => {
 test('fireEvent triggers useEffect calls', () => {
   const effectCb = jest.fn()
   function Counter() {
-    React.useEffect(effectCb)
     const [count, setCount] = React.useState(0)
+    React.useEffect(effectCb, [count])
     return <button onClick={() => setCount(count + 1)}>{count}</button>
   }
   const {
@@ -37,7 +37,7 @@ test('fireEvent triggers useEffect calls', () => {
 test('calls to hydrate will run useEffects', () => {
   const effectCb = jest.fn()
   function MyUselessComponent() {
-    React.useEffect(effectCb)
+    React.useEffect(effectCb, [])
     return null
   }
   render(<MyUselessComponent />, {hydrate: true})

--- a/src/__tests__/cleanup.js
+++ b/src/__tests__/cleanup.js
@@ -31,7 +31,7 @@ test('cleanup runs effect cleanup functions', () => {
   const spy = jest.fn()
 
   const Test = () => {
-    React.useEffect(() => spy)
+    React.useEffect(() => spy, [])
 
     return null
   }

--- a/src/__tests__/events.js
+++ b/src/__tests__/events.js
@@ -191,7 +191,7 @@ eventTypes.forEach(({type, events, elementType, init}) => {
             return () => {
               element.removeEventListener(nativeEventName, spy)
             }
-          })
+          }, [])
           return <Element ref={ref} />
         }
 

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -148,7 +148,7 @@ test('hydrate can have a wrapper', () => {
   function WrapperComponent({children}) {
     React.useEffect(() => {
       wrapperComponentMountEffect()
-    })
+    }, [])
 
     return children
   }

--- a/src/pure.js
+++ b/src/pure.js
@@ -255,7 +255,7 @@ function renderHook(renderCallback, options = {}) {
 
     React.useEffect(() => {
       result.current = pendingResult
-    })
+    }, [pendingResult])
 
     return null
   }


### PR DESCRIPTION
**What**:

<!-- Why are these changes necessary? -->
I added a dependency array for `useEffect`.

**What**:
It would be clearer to add a dependency array, and some code already has one.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
