### PR TITLE
fix: log globals warning only once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
     teardown(() => {
       cleanup()
     })
-  } else {
+  } else if (!process.env.RTL_AFTEREACH_WARNING_LOGGED) {
+    process.env.RTL_AFTEREACH_WARNING_LOGGED = true
     console.warn(
       `The current test runner does not support afterEach/teardown hooks. This means we won't be able to run automatic cleanup and you should be calling cleanup() manually.`,
     )
@@ -39,7 +40,8 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
     afterAll(() => {
       setReactActEnvironment(previousIsReactActEnvironment)
     })
-  } else {
+  } else if (!process.env.RTL_AFTERALL_WARNING_LOGGED) {
+    process.env.RTL_AFTERALL_WARNING_LOGGED = true
     console.warn(
       'The current test runner does not support beforeAll/afterAll hooks. This means you should be setting IS_REACT_ACT_ENVIRONMENT manually.',
     )


### PR DESCRIPTION
**What**: Resolves #1249 

<!-- Why are these changes necessary? -->

**Why**: To prevent the warning from being logged in every test suite.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
