### PR TITLE
fix: guard against process and process.env not defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,10 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
     teardown(() => {
       cleanup()
     })
-  } else if (!process.env.RTL_AFTEREACH_WARNING_LOGGED) {
+  } else if (process?.env && !process.env.RTL_AFTEREACH_WARNING_LOGGED) {
     process.env.RTL_AFTEREACH_WARNING_LOGGED = true
     console.warn(
-      `The current test runner does not support afterEach/teardown hooks. This means we won't be able to run automatic cleanup and you should be calling cleanup() manually.`,
+      `The current test runner does not support afterEach/teardown hooks or globals are not injected. This means we won't be able to run automatic cleanup and you should be calling cleanup() manually.`,
     )
   }
 
@@ -40,10 +40,10 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
     afterAll(() => {
       setReactActEnvironment(previousIsReactActEnvironment)
     })
-  } else if (!process.env.RTL_AFTERALL_WARNING_LOGGED) {
+  } else if (process?.env && !process.env.RTL_AFTERALL_WARNING_LOGGED) {
     process.env.RTL_AFTERALL_WARNING_LOGGED = true
     console.warn(
-      'The current test runner does not support beforeAll/afterAll hooks. This means you should be setting IS_REACT_ACT_ENVIRONMENT manually.',
+      'The current test runner does not support beforeAll/afterAll hooks or globals are not injected. This means you should be setting IS_REACT_ACT_ENVIRONMENT manually.',
     )
   }
 }


### PR DESCRIPTION
**What**: This PR guards against `process` being not defined in browser environments.

<!-- Why are these changes necessary? -->

**Why**: It's breaking in browser environments.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
CC: @AviVahl