### PR TITLE
fix: revert missing hooks warnings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,11 +20,6 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
     teardown(() => {
       cleanup()
     })
-  } else if (!process.env.RTL_AFTEREACH_WARNING_LOGGED) {
-    process.env.RTL_AFTEREACH_WARNING_LOGGED = true
-    console.warn(
-      `The current test runner does not support afterEach/teardown hooks. This means we won't be able to run automatic cleanup and you should be calling cleanup() manually.`,
-    )
   }
 
   // No test setup with other test runners available
@@ -40,11 +35,6 @@ if (typeof process === 'undefined' || !process.env?.RTL_SKIP_AUTO_CLEANUP) {
     afterAll(() => {
       setReactActEnvironment(previousIsReactActEnvironment)
     })
-  } else if (!process.env.RTL_AFTERALL_WARNING_LOGGED) {
-    process.env.RTL_AFTERALL_WARNING_LOGGED = true
-    console.warn(
-      'The current test runner does not support beforeAll/afterAll hooks. This means you should be setting IS_REACT_ACT_ENVIRONMENT manually.',
-    )
   }
 }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: This PR reverts #1252 and #1244. Resolves #1253.

<!-- Why are these changes necessary? -->

**Why**: The changes here doesn't provide much added value and should be properly documented instead.
Since we can't provide a good experience for users that are manually calling `afterEach` without globals, we prefer documenting it properly.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
