### PR TITLE
chore: update stackblitz url in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -60,13 +60,8 @@ https://github.com/testing-library/testing-library-docs
 ### Reproduction:
 
 <!--
-If possible, please create a repository that reproduces the issue with the
-minimal amount of code possible.
-
-Template repo: https://github.com/testing-library/dom-testing-library-template
-
-Or if you can, try to reproduce the issue in a Codesandbox. You can fork the one
-here: https://codesandbox.io/s/5z6x4r7n0p
+If possible, please try to reproduce this issue in Stackblitz. You can fork the one
+here: https://testing-library.com/new-rtl
 -->
 
 ### Problem description:


### PR DESCRIPTION
**What**: This PR adds Stackblitz url for reproduction in the Issue template.