### PR TITLE
Drop usage of react-dom/test-utils

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [14, 16, 18]
-        react: [latest, canary, experimental]
+        react: ['18.x', latest, canary, experimental]
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+const {jest: jestConfig} = require('kcd-scripts/config')
+
+module.exports = Object.assign(jestConfig, {
+  coverageThreshold: {
+    ...jestConfig.coverageThreshold,
+    // Full coverage across the build matrix (React 18, 19) but not in a single job
+    // Ful coverage is checked via codecov
+    './src/act-compat.js': {
+      // minimum coverage of jobs using React 18 and 19
+      branches: 90,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "jest-diff": "^29.4.1",
     "kcd-scripts": "^13.0.0",
     "npm-run-all": "^4.1.5",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "18.3.0-canary-4b2a1115a-20240202",
+    "react-dom": "18.3.0-canary-4b2a1115a-20240202",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "jest-diff": "^29.4.1",
     "kcd-scripts": "^13.0.0",
     "npm-run-all": "^4.1.5",
-    "react": "18.3.0-canary-4b2a1115a-20240202",
-    "react-dom": "18.3.0-canary-4b2a1115a-20240202",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
-    "react": "^18.3.0-canary",
-    "react-dom": "^18.3.0-canary"
+    "react": "^18.0.0 || ^18.3.0-canary",
+    "react-dom": "^18.0.0 || ^18.3.0-canary"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.3.0-canary",
+    "react-dom": "^18.3.0-canary"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/src/__tests__/new-act.js
+++ b/src/__tests__/new-act.js
@@ -1,10 +1,13 @@
 let asyncAct
 
-jest.mock('react-dom/test-utils', () => ({
-  act: cb => {
-    return cb()
-  },
-}))
+jest.mock('react', () => {
+  return {
+    ...jest.requireActual('react'),
+    act: cb => {
+      return cb()
+    },
+  }
+})
 
 beforeEach(() => {
   jest.resetModules()

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -212,29 +212,4 @@ describe('render API', () => {
 
     expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(1)
   })
-
-  test('legacyRoot uses legacy ReactDOM.render', () => {
-    expect(() => {
-      render(<div />, {legacyRoot: true})
-    }).toErrorDev(
-      [
-        "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-      ],
-      {withoutStack: true},
-    )
-  })
-
-  test('legacyRoot uses legacy ReactDOM.hydrate', () => {
-    const ui = <div />
-    const container = document.createElement('div')
-    container.innerHTML = ReactDOMServer.renderToString(ui)
-    expect(() => {
-      render(ui, {container, hydrate: true, legacyRoot: true})
-    }).toErrorDev(
-      [
-        "Warning: ReactDOM.hydrate is no longer supported in React 18. Use hydrateRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-      ],
-      {withoutStack: true},
-    )
-  })
 })

--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -60,28 +60,3 @@ test('allows wrapper components', async () => {
 
   expect(result.current).toEqual('provided')
 })
-
-test('legacyRoot uses legacy ReactDOM.render', () => {
-  const Context = React.createContext('default')
-  function Wrapper({children}) {
-    return <Context.Provider value="provided">{children}</Context.Provider>
-  }
-  let result
-  expect(() => {
-    result = renderHook(
-      () => {
-        return React.useContext(Context)
-      },
-      {
-        wrapper: Wrapper,
-        legacyRoot: true,
-      },
-    ).result
-  }).toErrorDev(
-    [
-      "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-    ],
-    {withoutStack: true},
-  )
-  expect(result.current).toEqual('provided')
-})

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -1,6 +1,6 @@
-import * as testUtils from 'react-dom/test-utils'
+import * as React from 'react'
 
-const domAct = testUtils.act
+const reactAct = React.act
 
 function getGlobalThis() {
   /* istanbul ignore else */
@@ -78,7 +78,7 @@ function withGlobalActEnvironment(actImplementation) {
   }
 }
 
-const act = withGlobalActEnvironment(domAct)
+const act = withGlobalActEnvironment(reactAct)
 
 export default act
 export {

--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -1,6 +1,7 @@
 import * as React from 'react'
+import * as DeprecatedReactTestUtils from 'react-dom/test-utils'
 
-const reactAct = React.act
+const reactAct = React.act ?? DeprecatedReactTestUtils.act
 
 function getGlobalThis() {
   /* istanbul ignore else */

--- a/tests/shouldIgnoreConsoleError.js
+++ b/tests/shouldIgnoreConsoleError.js
@@ -36,6 +36,7 @@ module.exports = function shouldIgnoreConsoleError(format) {
         // Ignore it too.
         return true
       }
+      // TODO: Suppress deprecation warning from react-dom/test-utils
     }
   }
   // Looks legit

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -67,17 +67,12 @@ export interface RenderOptions<
    */
   baseElement?: BaseElement
   /**
-   * If `hydrate` is set to `true`, then it will render with `ReactDOM.hydrate`. This may be useful if you are using server-side
-   *  rendering and use ReactDOM.hydrate to mount your components.
+   * If `hydrate` is set to `true`, then it will create a root with `ReactDOMClient.hydrateRoot`. This may be useful if you are using server-side
+   *  rendering and use ReactDOMClient.hydrateRoot to mount your components.
    *
    *  @see https://testing-library.com/docs/react-testing-library/api/#hydrate)
    */
   hydrate?: boolean
-  /**
-   * Set to `true` if you want to force synchronous `ReactDOM.render`.
-   * Otherwise `render` will default to concurrent React if available.
-   */
-  legacyRoot?: boolean
   /**
    * Queries to bind. Overrides the default set from DOM Testing Library unless merged.
    *


### PR DESCRIPTION
**BREAKING CHANGE**
The `legacyRoot` option is no longer supported now that `ReactDOM.render` has been removed from React. There is no alternative.

To ensure compatibility with React Testing Library 15, make sure you're not using the `legacyRoot` option in any of your calls to `render` from React Testing Library. 

React 18 is still supported but you will see deprecation warnings from `react-dom/test-utils`. Either suppress these warnings or switch to React 19.