### PR TITLE
fix: Remove unused types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,6 @@ import {
   BoundFunction,
   prettyFormat,
 } from '@testing-library/dom'
-import {Renderer} from 'react-dom'
 import {act as reactAct} from 'react-dom/test-utils'
 
 export * from '@testing-library/dom'


### PR DESCRIPTION
Removing this now since that'll also ensure forwards compatibility with React 19 from a types perspective.