### PR TITLE
chore: Fix tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,6 +55,8 @@ jobs:
       - name: ⚛️ Setup react
         run: npm install react@${{ matrix.react }} react-dom@${{ matrix.react }}
 
+      - run: npm ls jest-diff
+
       - name: ▶️ Run validate script
         run: npm run validate
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,8 +55,6 @@ jobs:
       - name: ⚛️ Setup react
         run: npm install react@${{ matrix.react }} react-dom@${{ matrix.react }}
 
-      - run: npm ls jest-diff
-
       - name: ▶️ Run validate script
         run: npm run validate
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+const {jest: jestConfig} = require('kcd-scripts/config')
+
+module.exports = Object.assign(jestConfig, {
+  coverageThreshold: {
+    ...jestConfig.coverageThreshold,
+    // Full coverage across the build matrix (React versions) but not in a single job
+    // Ful coverage is checked via codecov
+    './src/pure.js': {
+      // minimum coverage of jobs using different React versions
+      branches: 97,
+      functions: 88,
+      lines: 94,
+      statements: 94,
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "chalk": "^4.1.2",
     "dotenv-cli": "^4.0.0",
-    "jest-diff": "^29.4.1",
+    "jest-diff": "^29.7.0",
     "kcd-scripts": "^13.0.0",
     "npm-run-all": "^4.1.5",
     "react": "^18.0.0",

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -3,6 +3,13 @@ import ReactDOM from 'react-dom'
 import ReactDOMServer from 'react-dom/server'
 import {fireEvent, render, screen, configure} from '../'
 
+// Needs to be changed to 19.0.0 once alpha started.
+const isReactExperimental = React.version.startsWith('18.3.0-experimental')
+const isReactCanary = React.version.startsWith('18.3.0')
+
+// Needs to be changed to isReactExperimental || isReactCanary once alpha started.
+const testGateReact18 = isReactExperimental ? test.skip : test
+
 describe('render API', () => {
   let originalConfig
   beforeEach(() => {
@@ -213,27 +220,35 @@ describe('render API', () => {
     expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(1)
   })
 
-  test('legacyRoot uses legacy ReactDOM.render', () => {
+  testGateReact18('legacyRoot uses legacy ReactDOM.render', () => {
     expect(() => {
       render(<div />, {legacyRoot: true})
     }).toErrorDev(
-      [
-        "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-      ],
+      isReactCanary
+        ? [
+            "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://react.dev/link/switch-to-createroot",
+          ]
+        : [
+            "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
+          ],
       {withoutStack: true},
     )
   })
 
-  test('legacyRoot uses legacy ReactDOM.hydrate', () => {
+  testGateReact18('legacyRoot uses legacy ReactDOM.hydrate', () => {
     const ui = <div />
     const container = document.createElement('div')
     container.innerHTML = ReactDOMServer.renderToString(ui)
     expect(() => {
       render(ui, {container, hydrate: true, legacyRoot: true})
     }).toErrorDev(
-      [
-        "Warning: ReactDOM.hydrate is no longer supported in React 18. Use hydrateRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-      ],
+      isReactCanary
+        ? [
+            "Warning: ReactDOM.hydrate is no longer supported in React 18. Use hydrateRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://react.dev/link/switch-to-createroot",
+          ]
+        : [
+            "Warning: ReactDOM.hydrate is no longer supported in React 18. Use hydrateRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
+          ],
       {withoutStack: true},
     )
   })

--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -1,6 +1,13 @@
 import React from 'react'
 import {renderHook} from '../pure'
 
+// Needs to be changed to 19.0.0 once alpha started.
+const isReactExperimental = React.version.startsWith('18.3.0-experimental')
+const isReactCanary = React.version.startsWith('18.3.0')
+
+// Needs to be changed to isReactExperimental || isReactCanary once alpha started.
+const testGateReact18 = isReactExperimental ? test.skip : test
+
 test('gives committed result', () => {
   const {result} = renderHook(() => {
     const [state, setState] = React.useState(1)
@@ -61,7 +68,7 @@ test('allows wrapper components', async () => {
   expect(result.current).toEqual('provided')
 })
 
-test('legacyRoot uses legacy ReactDOM.render', () => {
+testGateReact18('legacyRoot uses legacy ReactDOM.render', () => {
   const Context = React.createContext('default')
   function Wrapper({children}) {
     return <Context.Provider value="provided">{children}</Context.Provider>
@@ -78,9 +85,13 @@ test('legacyRoot uses legacy ReactDOM.render', () => {
       },
     ).result
   }).toErrorDev(
-    [
-      "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-    ],
+    isReactCanary
+      ? [
+          "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://react.dev/link/switch-to-createroot",
+        ]
+      : [
+          "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
+        ],
     {withoutStack: true},
   )
   expect(result.current).toEqual('provided')

--- a/tests/toWarnDev.js
+++ b/tests/toWarnDev.js
@@ -32,6 +32,9 @@ const util = require('util')
 const jestDiff = require('jest-diff').diff
 const shouldIgnoreConsoleError = require('./shouldIgnoreConsoleError')
 
+console.log({jestDiff})
+console.log(require('jest-diff'))
+
 function normalizeCodeLocInfo(str) {
   if (typeof str !== 'string') {
     return str

--- a/tests/toWarnDev.js
+++ b/tests/toWarnDev.js
@@ -32,9 +32,6 @@ const util = require('util')
 const jestDiff = require('jest-diff').diff
 const shouldIgnoreConsoleError = require('./shouldIgnoreConsoleError')
 
-console.log({jestDiff})
-console.log(require('jest-diff'))
-
 function normalizeCodeLocInfo(str) {
   if (typeof str !== 'string') {
     return str

--- a/tests/toWarnDev.js
+++ b/tests/toWarnDev.js
@@ -29,7 +29,7 @@ SOFTWARE.
 /* eslint-disable func-names */
 /* eslint-disable complexity */
 const util = require('util')
-const jestDiff = require('jest-diff').default
+const jestDiff = require('jest-diff').diff
 const shouldIgnoreConsoleError = require('./shouldIgnoreConsoleError')
 
 function normalizeCodeLocInfo(str) {


### PR DESCRIPTION
Fixing 

```
[test] FAIL src/__tests__/render.js (9.164 s)
[test]   ● render API › legacyRoot uses legacy ReactDOM.render
[test] 
[test]     TypeError: jestDiff is not a function
[test] 
[test]       161 |           errorMessage =
[test]       162 |             'Unexpected warning recorded: ' +
[test]     > 163 |             jestDiff(expectedMessages[0], normalizedMessage)
[test]           |             ^
[test]       164 |         } else {
[test]       165 |           errorMessage =
[test]       166 |             'Unexpected warning recorded: ' +
[test] 
[test]       at console.jestDiff (tests/toWarnDev.js:163:13)
[test]       at printWarning (node_modules/react-dom/cjs/react-dom.development.js:105:30)
[test]       at error (node_modules/react-dom/cjs/react-dom.development.js:79:7)
[test]       at Object.render (node_modules/react-dom/cjs/react-dom.development.js:37824:5)
[test]       at Object.render (src/pure.js:133:16)
[test]       at render (src/pure.js:152:12)
[test]       at callback (src/act-compat.js:42:24)
[test]       at act (node_modules/react/cjs/react.development.js:2719:16)
[test]       at actImplementation (src/act-compat.js:[41](https://github.com/testing-library/react-testing-library/actions/runs/8349938959/job/22855248000?pr=1287#step:7:42):25)
[test]       at renderRoot (src/pure.js:1[45](https://github.com/testing-library/react-testing-library/actions/runs/8349938959/job/22855248000?pr=1287#step:7:46):6)
[test]       at renderRoot (src/pure.js:241:10)
[test]       at src/__tests__/render.js:218:13
[test]       at Object.callback (tests/toWarnDev.js:185:9)
[test]       at __EXTERNAL_MATCHER_TRAP__ (node_modules/expect/build/index.js:325:30)
[test]       at Object.throwingMatcher [as toErrorDev] (node_modules/expect/build/index.js:326:15)
[test]       at Object.toErrorDev (src/__tests__/render.js:219:8)
```

-- https://github.com/testing-library/react-testing-library/actions/runs/8349938959/job/22855248000?pr=1287#step:7:43

Also adjusts to changed warnings in https://github.com/facebook/react/pull/28477