### PR TITLE
chore: Update Codecov configuration to latest

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
@@ -59,9 +59,11 @@ jobs:
         run: npm run validate
 
       - name: ⬆️ Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: true
           flags: ${{ matrix.react }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   release:
     permissions:
@@ -76,10 +78,10 @@ jobs:
       github.event_name == 'push' }}
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 14
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: 100%
+        threshold: 0%
+        flags:
+          - canary
+          - experimental
+          - latest
+        branches:
+          - main
+          - 12.x
+        if_ci_failed: success
+        if_not_found: failure
+        informational: false
+        only_pulls: false
+github_checks:
+  annotations: true


### PR DESCRIPTION
Followed https://github.com/codecov/codecov-action#usage

Updated other actions as a drive-by (though checkout should probably also be latest for maximum interop with codecov action)

codecov/codecov-action docs: https://github.com/codecov/codecov-action#usage