### PR TITLE
chore: change canary version to specific prefix

### DIFF
--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -5,7 +5,7 @@ import {fireEvent, render, screen, configure} from '../'
 
 // Needs to be changed to 19.0.0 once alpha started.
 const isReactExperimental = React.version.startsWith('18.3.0-experimental')
-const isReactCanary = React.version.startsWith('18.3.0')
+const isReactCanary = React.version.startsWith('18.3.0-canary')
 
 // Needs to be changed to isReactExperimental || isReactCanary once alpha started.
 const testGateReact18 = isReactExperimental ? test.skip : test


### PR DESCRIPTION
Following this comment in @eps1lon's PR: https://github.com/testing-library/react-testing-library/pull/1288#discussion_r1531897751