### PR TITLE
Release: 15.0.0

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "installCommand": "install:csb",
   "sandboxes": ["new", "github/kentcdodds/react-testing-library-examples"],
-  "node": "14"
+  "node": "18"
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18]
+        node: [18, 20]
         react: ['18.x', latest, canary, experimental]
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^9.0.0",
+    "@testing-library/dom": "^10.0.0",
     "@types/react-dom": "^18.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "types/index.d.ts",
   "module": "dist/@testing-library/react.esm.js",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
BREAKING CHANGE: Minimum supported Node.js version is 18.0
BREAKING CHANGE: New version of `@testing-library/dom` changes various roles. Check out the changed tests in https://github.com/testing-library/dom-testing-library/commit/2c570553d8f31b008451398152a9bd30bce362b3 to get an overview about what changed.

More details about this change can be found in the [DTL release](https://github.com/testing-library/dom-testing-library/releases/tag/v10.0.0).