### PR TITLE
fix: Stop using nullish coalescing

### DIFF
--- a/src/act-compat.js
+++ b/src/act-compat.js
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import * as DeprecatedReactTestUtils from 'react-dom/test-utils'
 
-const reactAct = React.act ?? DeprecatedReactTestUtils.act
+const reactAct =
+  typeof React.act === 'function' ? React.act : DeprecatedReactTestUtils.act
 
 function getGlobalThis() {
   /* istanbul ignore else */


### PR DESCRIPTION
It's not supported by some older bundlers and we don't need to use the syntax to begin with (really). Will backport to 14.x since the latest 14.x was only out for 2 days.