### PR TITLE
fix: Improve `legacyRoot` error message

### DIFF
--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -234,7 +234,7 @@ describe('render API', () => {
     expect(() => {
       render(<div />, {legacyRoot: true})
     }).toThrowErrorMatchingInlineSnapshot(
-      `\`legacyRoot: true\` is not supported in this version of React. Please use React 18 instead.`,
+      `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.`,
     )
   })
 
@@ -259,7 +259,7 @@ describe('render API', () => {
     expect(() => {
       render(ui, {container, hydrate: true, legacyRoot: true})
     }).toThrowErrorMatchingInlineSnapshot(
-      `\`legacyRoot: true\` is not supported in this version of React. Please use React 18 instead.`,
+      `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.`,
     )
   })
 })

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -234,7 +234,7 @@ describe('render API', () => {
     expect(() => {
       render(<div />, {legacyRoot: true})
     }).toThrowErrorMatchingInlineSnapshot(
-      `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.`,
+      `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.`,
     )
   })
 
@@ -259,7 +259,7 @@ describe('render API', () => {
     expect(() => {
       render(ui, {container, hydrate: true, legacyRoot: true})
     }).toThrowErrorMatchingInlineSnapshot(
-      `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.`,
+      `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.`,
     )
   })
 })

--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -108,6 +108,6 @@ testGateReact19('legacyRoot throws', () => {
       },
     ).result
   }).toThrowErrorMatchingInlineSnapshot(
-    `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.`,
+    `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.`,
   )
 })

--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -108,6 +108,6 @@ testGateReact19('legacyRoot throws', () => {
       },
     ).result
   }).toThrowErrorMatchingInlineSnapshot(
-    `\`legacyRoot: true\` is not supported in this version of React. Please use React 18 instead.`,
+    `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.`,
   )
 })

--- a/src/pure.js
+++ b/src/pure.js
@@ -211,7 +211,7 @@ function render(
     const error = new Error(
       '`legacyRoot: true` is not supported in this version of React. ' +
         'If your app runs React 19 or later, you should remove this flag. ' +
-        'If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.',
+        'If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.',
     )
     Error.captureStackTrace(error, render)
     throw error
@@ -278,7 +278,7 @@ function renderHook(renderCallback, options = {}) {
     const error = new Error(
       '`legacyRoot: true` is not supported in this version of React. ' +
         'If your app runs React 19 or later, you should remove this flag. ' +
-        'If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.',
+        'If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.',
     )
     Error.captureStackTrace(error, renderHook)
     throw error

--- a/src/pure.js
+++ b/src/pure.js
@@ -209,7 +209,9 @@ function render(
 ) {
   if (legacyRoot && typeof ReactDOM.render !== 'function') {
     const error = new Error(
-      '`legacyRoot: true` is not supported in this version of React. Please use React 18 instead.',
+      '`legacyRoot: true` is not supported in this version of React. ' +
+        'If your app runs React 19 or later, you should remove this flag. ' +
+        'If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.',
     )
     Error.captureStackTrace(error, render)
     throw error
@@ -274,7 +276,9 @@ function renderHook(renderCallback, options = {}) {
 
   if (renderOptions.legacyRoot && typeof ReactDOM.render !== 'function') {
     const error = new Error(
-      '`legacyRoot: true` is not supported in this version of React. Please use React 18 instead.',
+      '`legacyRoot: true` is not supported in this version of React. ' +
+        'If your app runs React 19 or later, you should remove this flag. ' +
+        'If your app runs React 18 or earlier, and you need help with upgrading your app, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide.',
     )
     Error.captureStackTrace(error, renderHook)
     throw error


### PR DESCRIPTION
Applies suggestions by @wojtekmaj from https://github.com/testing-library/react-testing-library/pull/1294#discussion_r1557073011