### PR TITLE
fix: Don't raise TypeScript errors when hydating `document`

### DIFF
--- a/types/test.tsx
+++ b/types/test.tsx
@@ -206,6 +206,17 @@ export function testRenderHookProps() {
   unmount()
 }
 
+export function testContainer() {
+  render('a', {container: document.createElement('div')})
+  render('a', {container: document.createDocumentFragment()})
+  // @ts-expect-error Only allowed in React 19
+  render('a', {container: document})
+  render('a', {container: document.createElement('div'), hydrate: true})
+  // @ts-expect-error Only allowed for createRoot
+  render('a', {container: document.createDocumentFragment(), hydrate: true})
+  render('a', {container: document, hydrate: true})
+}
+
 /*
 eslint
   testing-library/prefer-explicit-assert: "off",


### PR DESCRIPTION
Closes https://github.com/testing-library/react-testing-library/issues/1250

As a follow-up, we need to make `@types/react-dom` a peer dependency. Since `react-dom` is a peer, the types also need to be peer. Otherwise you would get the wrong version of `@types/react-dom` if you'd install React 19.