### PR TITLE
feat: Move `@testing-library/dom` and `@types/react-dom`  to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,12 @@ primary guiding principle is:
 ## Installation
 
 This module is distributed via [npm][npm] which is bundled with [node][node] and
-should be installed as one of your project's `devDependencies`:
+should be installed as one of your project's `devDependencies`.  
+Starting from RTL version 16, you'll also need to install
+`@testing-library/dom`:
 
 ```
-npm install --save-dev @testing-library/react
+npm install --save-dev @testing-library/react @testing-library/dom
 ```
 
 or
@@ -108,10 +110,11 @@ or
 for installation via [yarn][yarn]
 
 ```
-yarn add --dev @testing-library/react
+yarn add --dev @testing-library/react @testing-library/dom
 ```
 
-This library has `peerDependencies` listings for `react` and `react-dom`.
+This library has `peerDependencies` listings for `react`, `react-dom` and
+starting from RTL version 16 also `@testing-library/dom`.
 
 _React Testing Library versions 13+ require React v18. If your project uses an
 older version of React, be sure to install version 12:_

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com)",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^10.0.0"
+    "@babel/runtime": "^7.12.5"
   },
   "devDependencies": {
-    "@types/react-dom": "^18.2.25",
+    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^5.11.6",
+    "@types/react-dom": "^18.2.25",
     "chalk": "^4.1.2",
     "dotenv-cli": "^4.0.0",
     "jest-diff": "^29.7.0",
@@ -62,6 +62,7 @@
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
+    "@testing-library/dom": "^10.0.0",
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^10.0.0",
-    "@types/react-dom": "^18.0.0"
+    "@testing-library/dom": "^10.0.0"
   },
   "devDependencies": {
+    "@types/react-dom": "^18.2.25",
     "@testing-library/jest-dom": "^5.11.6",
     "chalk": "^4.1.2",
     "dotenv-cli": "^4.0.0",
@@ -62,8 +62,14 @@
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
+    "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react-dom": {
+      "optional": true
+    }
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^5.11.6",
     "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.0",
     "chalk": "^4.1.2",
     "dotenv-cli": "^4.0.0",
     "jest-diff": "^29.7.0",
@@ -63,8 +64,8 @@
   },
   "peerDependencies": {
     "@testing-library/dom": "^10.0.0",
-    "@types/react-dom": "^18.0.0",
     "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },


### PR DESCRIPTION
Closes https://github.com/testing-library/react-testing-library/issues/1184
Docs: https://github.com/testing-library/testing-library-docs/pull/1384

**BREAKING CHANGE**:
`@testing-library/dom` was moved to a peer dependency and needs to be explicitly installed. This reduces the chance of having conflicting versions of `@testing-library/dom` installed that frequently caused bugs when used with `@testing-library/user-event`. We will also be able to allow new versions of `@testing-library/dom` being used withou a SemVer major release of `@testing-library/react` by just widening the peer dependency.
`@types/react-dom` needs to be installed if you're typechecking files using `@testing-library/react`.

Type dependencies need to match their runtime counterpart.
If `foo` is a dependency, `@types/foo` needs to be one as well.
If `foo` is a peer dependency, `@types/foo` needs to be one as well.
This is especially apparent if the constraint on `foo` spans multiple major versions.
If we'd make `@types/foo` a direct dependency, users couldn't control which major version they get.
Package managers would pick the highest.
By moving `@types/foo` to peer dependencies, users can control which version of `@types/foo` they have.

In our case specifically, you'd get type mismatches of `@types/react-dom` if we just widen the peer dependency constraint from `^18` to `^18 | ^19`. Currently, we're already compatible with the planned React 19 features so all we'd have to do is widen the constraint on release.