### PR TITLE
feat!: move dtl to peerDeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ primary guiding principle is:
 
 This module is distributed via [npm][npm] which is bundled with [node][node] and
 should be installed as one of your project's `devDependencies`.  
-Starting from RTL version 16, you'll also need to install `@testing-library/dom`:
+Starting from RTL version 16, you'll also need to install
+`@testing-library/dom`:
 
 ```
 npm install --save-dev @testing-library/react @testing-library/dom
@@ -112,7 +113,8 @@ for installation via [yarn][yarn]
 yarn add --dev @testing-library/react @testing-library/dom
 ```
 
-This library has `peerDependencies` listings for `react`, `react-dom` and starting from RTL version 16 also `@testing-library/dom`.
+This library has `peerDependencies` listings for `react`, `react-dom` and
+starting from RTL version 16 also `@testing-library/dom`.
 
 _React Testing Library versions 13+ require React v18. If your project uses an
 older version of React, be sure to install version 12:_

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ primary guiding principle is:
 ## Installation
 
 This module is distributed via [npm][npm] which is bundled with [node][node] and
-should be installed as one of your project's `devDependencies`:
+should be installed as one of your project's `devDependencies`.  
+Starting from RTL version 16, you'll also need to install `@testing-library/dom`:
 
 ```
-npm install --save-dev @testing-library/react
+npm install --save-dev @testing-library/react @testing-library/dom
 ```
 
 or
@@ -108,10 +109,10 @@ or
 for installation via [yarn][yarn]
 
 ```
-yarn add --dev @testing-library/react
+yarn add --dev @testing-library/react @testing-library/dom
 ```
 
-This library has `peerDependencies` listings for `react` and `react-dom`.
+This library has `peerDependencies` listings for `react`, `react-dom` and starting from RTL version 16 also `@testing-library/dom`.
 
 _React Testing Library versions 13+ require React v18. If your project uses an
 older version of React, be sure to install version 12:_

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@testing-library/dom": "^10.0.0",
     "@types/react-dom": "^18.0.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^5.11.6",
     "chalk": "^4.1.2",
     "dotenv-cli": "^4.0.0",
@@ -62,6 +62,7 @@
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
+    "@testing-library/dom": "^10.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },


### PR DESCRIPTION
BREAKING CHANGE

**What**: As we've seen some issues lately with people having multiple versions of DTL due to `user-event` setting it as a peer and since DTL has some sort of state (the `config`), we'd want to make sure that there's only one version of DTL.


I'll update the version in the text before merging as this might be RTL version 17.
Docs to follow in another PR.

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)