### PR TITLE
chore: Adjust tests to workaround 18.3.0 bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "jest-diff": "^29.7.0",
     "kcd-scripts": "^13.0.0",
     "npm-run-all": "^4.1.5",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.2"
   },

--- a/src/__tests__/stopwatch.js
+++ b/src/__tests__/stopwatch.js
@@ -40,7 +40,6 @@ class StopWatch extends React.Component {
 const sleep = t => new Promise(resolve => setTimeout(resolve, t))
 
 test('unmounts a component', async () => {
-  jest.spyOn(console, 'error').mockImplementation(() => {})
   const {unmount, container} = render(<StopWatch />)
   fireEvent.click(screen.getByText('Start'))
   unmount()
@@ -52,6 +51,4 @@ test('unmounts a component', async () => {
   // if it's not, then we'll call setState on an unmounted component
   // and get an error.
   await sleep(5)
-  // eslint-disable-next-line no-console
-  expect(console.error).not.toHaveBeenCalled()
 })

--- a/tests/shouldIgnoreConsoleError.js
+++ b/tests/shouldIgnoreConsoleError.js
@@ -36,6 +36,15 @@ module.exports = function shouldIgnoreConsoleError(format) {
         // Ignore it too.
         return true
       }
+      if (
+        format.startsWith(
+          'Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`.',
+        )
+      ) {
+        // This is a React bug in 18.3.0.
+        // Versions with `ReactDOMTestUtils.ac` being deprecated, should have `React.act`
+        return true
+      }
     }
   }
   // Looks legit


### PR DESCRIPTION
Work around https://github.com/facebook/react/issues/28915. Should be fixed in 18.3.0 but the special casing should remain in case we need to test against 18.3.0 specifically.