### PR TITLE
fix: export new act when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,14 @@
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
+    "@types/react": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/package.json
+++ b/package.json
@@ -51,12 +51,13 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",
+    "@types/react": "^18.3.1",
     "chalk": "^4.1.2",
     "dotenv-cli": "^4.0.0",
     "jest-diff": "^29.7.0",
     "kcd-scripts": "^13.0.0",
     "npm-run-all": "^4.1.5",
-    "react": "^18.3.0",
+    "react": "^18.3.1",
     "react-dom": "^18.3.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.2"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,8 @@ import {
   prettyFormat,
   Config as ConfigDTL,
 } from '@testing-library/dom'
-import {act as reactAct} from 'react-dom/test-utils'
+import {act as reactDeprecatedAct} from 'react-dom/test-utils'
+import {act as reactAct} from 'react'
 
 export * from '@testing-library/dom'
 
@@ -245,10 +246,10 @@ export function renderHook<
 export function cleanup(): void
 
 /**
- * Simply calls ReactDOMTestUtils.act(cb)
+ * Simply calls React.act(cb)
  * If that's not available (older version of react) then it
- * simply calls the given callback immediately
+ * simply calls the deprecated version which is ReactTestUtils.act(cb)
  */
 export const act: typeof reactAct extends undefined
-  ? (callback: () => void) => void
+  ? typeof reactDeprecatedAct
   : typeof reactAct

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@ import {
   Config as ConfigDTL,
 } from '@testing-library/dom'
 import {act as reactDeprecatedAct} from 'react-dom/test-utils'
+//@ts-ignore
 import {act as reactAct} from 'react'
 
 export * from '@testing-library/dom'
@@ -250,6 +251,6 @@ export function cleanup(): void
  * If that's not available (older version of react) then it
  * simply calls the deprecated version which is ReactTestUtils.act(cb)
  */
-export const act: typeof reactAct extends undefined
+export const act: typeof reactAct extends never
   ? typeof reactDeprecatedAct
   : typeof reactAct


### PR DESCRIPTION
Resolves https://github.com/testing-library/react-testing-library/issues/1316

**What**: This PR exports the correct act if available to avoid deprecation warnings.