### PR TITLE
fix: Ensure `act` is not `any` when `React.act` is not declared

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -251,6 +251,7 @@ export function cleanup(): void
  * If that's not available (older version of react) then it
  * simply calls the deprecated version which is ReactTestUtils.act(cb)
  */
-export const act: typeof reactAct extends never
+// IfAny<typeof reactAct, reactDeprecatedAct, reactAct> from https://stackoverflow.com/a/61626123/3406963
+export const act: 0 extends 1 & typeof reactAct
   ? typeof reactDeprecatedAct
   : typeof reactAct


### PR DESCRIPTION
Tested in https://github.com/eps1lon/rtl-deprecated-act-repro/commit/af593bdcf9296ded91df39ba803cfc09b67fd691

Required for https://github.com/vercel/front/pull/32113

