### PR TITLE
support `document` containers in cleanup

### DIFF
--- a/src/pure.js
+++ b/src/pure.js
@@ -263,7 +263,7 @@ function cleanup() {
     act(() => {
       root.unmount()
     })
-    if (container.parentNode === document.body) {
+    if (document.body !== null && container.parentNode === document.body) {
       document.body.removeChild(container)
     }
   })


### PR DESCRIPTION
**What**:

When `container` is set to `document`, the cleanup step fails:

```
TypeError: Cannot read properties of null (reading 'removeChild')
```

This is because the code assumes `document.body` exists:

```
    if (container.parentNode === document.body) {
      document.body.removeChild(container);
    }
```

In reality, both `container.parentNode` _and_ `document.body` are `null`.

**Why**:

The tests erroneously fail.

**How**:

The attempt to remove the container from the body now only occurs when the body exists.

**Checklist**:

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs) N/A
- [ ] Tests
- [ ] TypeScript definitions updated N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

resolves #1329