### PR TITLE
Fix type import from react-dom

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,6 @@
 // TypeScript Version: 3.8
 import * as ReactDOMClient from 'react-dom/client'
+import { Container as RendererableContainer } from 'react-dom'
 import {
   queries,
   Queries,
@@ -52,7 +53,6 @@ export type BaseRenderOptions<
   BaseElement extends RendererableContainer | HydrateableContainer,
 > = RenderOptions<Q, Container, BaseElement>
 
-type RendererableContainer = ReactDOMClient.Container
 type HydrateableContainer = Parameters<typeof ReactDOMClient['hydrateRoot']>[0]
 /** @deprecated */
 export interface ClientRenderOptions<


### PR DESCRIPTION
**What**:

Fix the imported `Container` type from `react-dom`

**Why**:

The `react-dom/client` module does not export the `Container` type, only `react-dom` does.

**How**:

Updating types/index.d.ts

**Checklist**:

- [ ] ~Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)~ (N/A)
- [ ] ~Tests~ (N/A)
- [x] TypeScript definitions updated
- [x] Ready to be merged

Thanks for the great library! 👍 