### PR TITLE
fix: esm output's extension to .mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple and complete React DOM testing utilities that encourage good testing practices.",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
-  "module": "dist/@testing-library/react.esm.js",
+  "module": "dist/@testing-library/react.esm.mjs",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
**What**:
**Why**:
More Information: https://github.com/kentcdodds/kcd-scripts/pull/244

**How**:
Change module field extension to `.mjs` and upgrade `kcd-scripts` after [pr](https://github.com/kentcdodds/kcd-scripts/pull/244) released.

**Checklist**:

- [ ] Documentation added to the
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged

Resolves: #1338 testing-library/user-event#1213
