### PR TITLE
test: Run with relevant React stable types

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,6 +55,12 @@ jobs:
       - name: ⚛️ Setup react
         run: npm install react@${{ matrix.react }} react-dom@${{ matrix.react }}
 
+      - name: ⚛️ Setup react types
+        if: ${{ matrix.react != 'canary' && matrix.react != 'experimental' }}
+        run:
+          npm install @types/react@${{ matrix.react }} @types/react-dom@${{
+          matrix.react }}
+
       - name: ▶️ Run validate script
         run: npm run validate
 


### PR DESCRIPTION
This has no effect right now since `latest` and `18.x` point at the same version.
Once React 19 is out, we'll be running tests in both 18 and 19.
The types should match that dimension.

Ideally, we'd be able to test RC types but npm claims `npm install @types/react@npm:types-react@rc` is an invalid comparator.
Putting that in the package.json works but I'm too lazy to write a dedicated script right now.