### PR TITLE
Fix React Canary and Experimental tests

### DIFF
--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,5 +1,9 @@
 import '@testing-library/jest-dom/extend-expect'
 import './failOnUnexpectedConsoleCalls'
 import {TextEncoder} from 'util'
+import {MessageChannel} from 'worker_threads'
 
 global.TextEncoder = TextEncoder
+// TODO: Revisit once https://github.com/jsdom/jsdom/issues/2448 is resolved
+// This isn't perfect but good enough.
+global.MessageChannel = MessageChannel


### PR DESCRIPTION
`react-dom/server` requires `MessageChannel` now. We polyfill it with the one from `worker_threads`. Don't try this at home.