### PR TITLE
feat: Add support for React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^5.11.6",
-    "@types/react": "^18.3.1",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "chalk": "^4.1.2",
     "dotenv-cli": "^4.0.0",
     "jest-diff": "^29.7.0",
@@ -64,10 +64,10 @@
   },
   "peerDependencies": {
     "@testing-library/dom": "^10.0.0",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "@types/react": "^18.0.0 || ^19.0.0",
+    "@types/react-dom": "^18.0.0 || ^19.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -128,7 +128,11 @@ export function wrappedRender(
   ui: React.ReactNode,
   options?: pure.RenderOptions,
 ) {
-  const Wrapper = ({children}: {children: React.ReactNode}): JSX.Element => {
+  const Wrapper = ({
+    children,
+  }: {
+    children: React.ReactNode
+  }): React.JSX.Element => {
     return <div>{children}</div>
   }
 


### PR DESCRIPTION
Just relaxing peer dependencies and adjusting for `@types/react@19` in a backwards compatible manner.

Closes https://github.com/testing-library/react-testing-library/issues/1364