### PR TITLE
test: Use React 19 by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "jest-diff": "^29.7.0",
     "kcd-scripts": "^13.0.0",
     "npm-run-all": "^4.1.5",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.2"
   },


### PR DESCRIPTION
i.e. update `devDependencies` to use 19.
18 is still tested in CI.
