### PR TITLE
feat: add render hook support for multiple arguments

### DIFF
--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -111,3 +111,28 @@ testGateReact19('legacyRoot throws', () => {
     `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.`,
   )
 })
+
+test('supports initialArgs for multi-parameter hooks', () => {
+  const useTestHook = (a, b, c) => a + b + c
+  const {result} = renderHook(useTestHook, {initialArgs: [1, 2, 3]})
+
+  expect(result.current).toBe(6)
+})
+
+test('rerender supports multiple parameters', () => {
+  const useTestHook = (a, b) => a * b
+  const {result, rerender} = renderHook(useTestHook, {initialArgs: [2, 3]})
+
+  expect(result.current).toBe(6)
+
+  rerender(4, 5)
+  expect(result.current).toBe(20)
+})
+
+test('throws error when both initialProps and initialArgs are used', () => {
+  const useTestHook = (a, b) => a + b
+
+  expect(() =>
+    renderHook(useTestHook, {initialProps: 1, initialArgs: [2, 3]}),
+  ).toThrow('Cannot use both initialProps and initialArgs. Choose one.')
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -249,6 +249,7 @@ export interface RenderHookOptions<
    * to use the rerender utility to change the values passed to your hook.
    */
   initialProps?: Props | undefined
+  initialArgs?: Props | undefined
 }
 
 /**
@@ -262,7 +263,7 @@ export function renderHook<
   Container extends RendererableContainer | HydrateableContainer = HTMLElement,
   BaseElement extends RendererableContainer | HydrateableContainer = Container,
 >(
-  render: (initialProps: Props) => Result,
+  render: (initialProps: Props, initialArgs: Props) => Result,
   options?: RenderHookOptions<Props, Q, Container, BaseElement> | undefined,
 ): RenderHookResult<Result, Props>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add render hook support for multiple arguments

<!-- Why are these changes necessary? -->

**Why**: renderHook only supports a single argument via initialProps, making it hard to test hooks with multiple parameters. This PR introduces initialArgs to allow passing multiple arguments directly, improving flexibility and reducing workarounds.

<!-- How were these changes implemented? -->

**How**:

1. Added initialArgs support → Spreads arguments into the hook.
2. Updated rerender → Now accepts multiple parameters.
3. Ensured backward compatibility → initialProps remains unchanged.
4. Throws an error if both initialProps and initialArgs are used.
5. Added tests & updated docs → Validates behavior and documents usage.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
