### PR TITLE
Add `reactStrictMode` as an option to `render`

### DIFF
--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -262,4 +262,38 @@ describe('render API', () => {
       `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.`,
     )
   })
+
+  test('reactStrictMode in renderOptions has precedence over config when rendering', () => {
+    const wrapperComponentMountEffect = jest.fn()
+    function WrapperComponent({children}) {
+      React.useEffect(() => {
+        wrapperComponentMountEffect()
+      })
+
+      return children
+    }
+    const ui = <div />
+    configure({reactStrictMode: false})
+
+    render(ui, {wrapper: WrapperComponent, reactStrictMode: true})
+
+    expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(2);
+  })
+
+  test('reactStrictMode in config is used when renderOptions does not specify reactStrictMode', () => {
+    const wrapperComponentMountEffect = jest.fn()
+    function WrapperComponent({children}) {
+      React.useEffect(() => {
+        wrapperComponentMountEffect()
+      })
+
+      return children
+    }
+    const ui = <div />
+    configure({reactStrictMode: true})
+
+    render(ui, {wrapper: WrapperComponent})
+
+    expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(2);
+  })
 })

--- a/src/__tests__/render.js
+++ b/src/__tests__/render.js
@@ -277,7 +277,7 @@ describe('render API', () => {
 
     render(ui, {wrapper: WrapperComponent, reactStrictMode: true})
 
-    expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(2);
+    expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(2)
   })
 
   test('reactStrictMode in config is used when renderOptions does not specify reactStrictMode', () => {
@@ -294,6 +294,6 @@ describe('render API', () => {
 
     render(ui, {wrapper: WrapperComponent})
 
-    expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(2);
+    expect(wrapperComponentMountEffect).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import {renderHook} from '../pure'
+import React, {useEffect} from 'react'
+import {configure, renderHook} from '../pure'
 
 const isReact18 = React.version.startsWith('18.')
 const isReact19 = React.version.startsWith('19.')
@@ -110,4 +110,32 @@ testGateReact19('legacyRoot throws', () => {
   }).toThrowErrorMatchingInlineSnapshot(
     `\`legacyRoot: true\` is not supported in this version of React. If your app runs React 19 or later, you should remove this flag. If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.`,
   )
+})
+
+describe('reactStrictMode', () => {
+  let originalConfig
+  beforeEach(() => {
+    // Grab the existing configuration so we can restore
+    // it at the end of the test
+    configure(existingConfig => {
+      originalConfig = existingConfig
+      // Don't change the existing config
+      return {}
+    })
+  })
+
+  afterEach(() => {
+    configure(originalConfig)
+  })
+
+  test('reactStrictMode in renderOptions has precedence over config when rendering', () => {
+    const hookMountEffect = jest.fn()
+    configure({reactStrictMode: false})
+
+    renderHook(() => useEffect(() => hookMountEffect()), {
+      reactStrictMode: true,
+    })
+
+    expect(hookMountEffect).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/pure.js
+++ b/src/pure.js
@@ -91,14 +91,24 @@ function wrapUiIfNeeded(innerElement, wrapperComponent) {
 
 function createConcurrentRoot(
   container,
-  {hydrate, onCaughtError, onRecoverableError, ui, wrapper: WrapperComponent, reactStrictMode},
+  {
+    hydrate,
+    onCaughtError,
+    onRecoverableError,
+    ui,
+    wrapper: WrapperComponent,
+    reactStrictMode,
+  },
 ) {
   let root
   if (hydrate) {
     act(() => {
       root = ReactDOMClient.hydrateRoot(
         container,
-        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent), reactStrictMode),
+        strictModeIfNeeded(
+          wrapUiIfNeeded(ui, WrapperComponent),
+          reactStrictMode,
+        ),
         {onCaughtError, onRecoverableError},
       )
     })
@@ -144,17 +154,31 @@ function createLegacyRoot(container) {
 
 function renderRoot(
   ui,
-  {baseElement, container, hydrate, queries, root, wrapper: WrapperComponent, reactStrictMode},
+  {
+    baseElement,
+    container,
+    hydrate,
+    queries,
+    root,
+    wrapper: WrapperComponent,
+    reactStrictMode,
+  },
 ) {
   act(() => {
     if (hydrate) {
       root.hydrate(
-        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent), reactStrictMode),
+        strictModeIfNeeded(
+          wrapUiIfNeeded(ui, WrapperComponent),
+          reactStrictMode,
+        ),
         container,
       )
     } else {
       root.render(
-        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent), reactStrictMode),
+        strictModeIfNeeded(
+          wrapUiIfNeeded(ui, WrapperComponent),
+          reactStrictMode,
+        ),
         container,
       )
     }

--- a/src/pure.js
+++ b/src/pure.js
@@ -77,8 +77,8 @@ const mountedContainers = new Set()
  */
 const mountedRootEntries = []
 
-function strictModeIfNeeded(innerElement) {
-  return getConfig().reactStrictMode
+function strictModeIfNeeded(innerElement, reactStrictMode) {
+  return reactStrictMode ?? getConfig().reactStrictMode
     ? React.createElement(React.StrictMode, null, innerElement)
     : innerElement
 }
@@ -91,14 +91,14 @@ function wrapUiIfNeeded(innerElement, wrapperComponent) {
 
 function createConcurrentRoot(
   container,
-  {hydrate, onCaughtError, onRecoverableError, ui, wrapper: WrapperComponent},
+  {hydrate, onCaughtError, onRecoverableError, ui, wrapper: WrapperComponent, reactStrictMode},
 ) {
   let root
   if (hydrate) {
     act(() => {
       root = ReactDOMClient.hydrateRoot(
         container,
-        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent)),
+        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent), reactStrictMode),
         {onCaughtError, onRecoverableError},
       )
     })
@@ -144,17 +144,17 @@ function createLegacyRoot(container) {
 
 function renderRoot(
   ui,
-  {baseElement, container, hydrate, queries, root, wrapper: WrapperComponent},
+  {baseElement, container, hydrate, queries, root, wrapper: WrapperComponent, reactStrictMode},
 ) {
   act(() => {
     if (hydrate) {
       root.hydrate(
-        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent)),
+        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent), reactStrictMode),
         container,
       )
     } else {
       root.render(
-        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent)),
+        strictModeIfNeeded(wrapUiIfNeeded(ui, WrapperComponent), reactStrictMode),
         container,
       )
     }
@@ -180,6 +180,7 @@ function renderRoot(
         baseElement,
         root,
         wrapper: WrapperComponent,
+        reactStrictMode,
       })
       // Intentionally do not return anything to avoid unnecessarily complicating the API.
       // folks can use all the same utilities we return in the first place that are bound to the container
@@ -212,6 +213,7 @@ function render(
     queries,
     hydrate = false,
     wrapper,
+    reactStrictMode,
   } = {},
 ) {
   if (onUncaughtError !== undefined) {
@@ -248,6 +250,7 @@ function render(
       onRecoverableError,
       ui,
       wrapper,
+      reactStrictMode,
     })
 
     mountedRootEntries.push({container, root})
@@ -273,6 +276,7 @@ function render(
     hydrate,
     wrapper,
     root,
+    reactStrictMode,
   })
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -156,6 +156,11 @@ export interface RenderOptions<
    *  @see https://testing-library.com/docs/react-testing-library/api/#wrapper
    */
   wrapper?: React.JSXElementConstructor<{children: React.ReactNode}> | undefined
+  /**
+   * When enabled, <StrictMode> is rendered around the inner element.
+   * If defined, overrides the value of `reactStrictMode` set in `configure`.
+   */
+  reactStrictMode?: boolean
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Add an ability to override the global `reactStrictMode` configuration on a per-test basis. 
<!-- Why are these changes necessary? -->

**Why**:

At MUI, our tests use a small wrapper around React Testing Library and [had this functionality](https://github.com/mui/material-ui/blob/a80e7b7270a1af786870b7a4ad84a1d17c4ce5bd/packages-internal/test-utils/src/createRenderer.tsx#L639). However, it was broken in the upgrade to React 19 since `StrictMode` won't double call effects on initial mount unless `StrictMode` is rendered at the root of the tree. Since we were rendering `React.StrictMode` inside the component passed to the `wrapper` property, effects aren't being called twice in React 19. 
<!-- How were these changes implemented? -->

**How**:

Added a `reactStrictMode` to `renderOptions`. 
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs): https://github.com/testing-library/testing-library-docs/pull/1479
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
