### PR TITLE
Allow setting a displayName for wrapper component created in renderHook

### DIFF
--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -53,10 +53,10 @@ test('allows rerendering', () => {
 test('allows setting a displayName', () => {
   let capturedElement = null
 
-  const spyWrapper = ({ children }) => {
+  const spyWrapper = ({children}) => {
     // Capture the hook element React creates
-    capturedElement = React.Children.only(children);
-    return <>{children}</>;
+    capturedElement = React.Children.only(children)
+    return <>{children}</>
   }
 
   const useMyLocalHook = jest.fn()
@@ -67,9 +67,9 @@ test('allows setting a displayName', () => {
   })
 
   expect(useMyLocalHook).toHaveBeenCalledTimes(1)
-  
+
   expect(capturedElement?.type?.displayName).toBe('CustomHookDisplayName')
-});
+})
 
 test('allows wrapper components', async () => {
   const Context = React.createContext('default')

--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -50,6 +50,27 @@ test('allows rerendering', () => {
   expect(result.current).toEqual(['right', expect.any(Function)])
 })
 
+test('allows setting a displayName', () => {
+  let capturedElement = null
+
+  const spyWrapper = ({ children }) => {
+    // Capture the hook element React creates
+    capturedElement = React.Children.only(children);
+    return <>{children}</>;
+  }
+
+  const useMyLocalHook = jest.fn()
+
+  renderHook(useMyLocalHook, {
+    wrapper: spyWrapper,
+    displayName: 'CustomHookDisplayName',
+  })
+
+  expect(useMyLocalHook).toHaveBeenCalledTimes(1)
+  
+  expect(capturedElement?.type?.displayName).toBe('CustomHookDisplayName')
+});
+
 test('allows wrapper components', async () => {
   const Context = React.createContext('default')
   function Wrapper({children}) {

--- a/src/pure.js
+++ b/src/pure.js
@@ -343,7 +343,7 @@ function renderHook(renderCallback, options = {}) {
   }
 
   if (displayName !== undefined) {
-    TestComponent.displayName = displayName;
+    TestComponent.displayName = displayName
   }
 
   const {rerender: baseRerender, unmount} = render(

--- a/src/pure.js
+++ b/src/pure.js
@@ -318,7 +318,7 @@ function cleanup() {
 }
 
 function renderHook(renderCallback, options = {}) {
-  const {initialProps, ...renderOptions} = options
+  const {initialProps, displayName, ...renderOptions} = options
 
   if (renderOptions.legacyRoot && typeof ReactDOM.render !== 'function') {
     const error = new Error(
@@ -340,6 +340,10 @@ function renderHook(renderCallback, options = {}) {
     })
 
     return null
+  }
+
+  if (displayName !== undefined) {
+    TestComponent.displayName = displayName;
   }
 
   const {rerender: baseRerender, unmount} = render(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -253,7 +253,8 @@ export interface RenderHookOptions<
    * The argument passed to the renderHook callback. Can be useful if you plan
    * to use the rerender utility to change the values passed to your hook.
    */
-  initialProps?: Props | undefined
+  initialProps?: Props | undefined,
+  displayName?: React.FunctionComponent['displayName'],
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -253,8 +253,8 @@ export interface RenderHookOptions<
    * The argument passed to the renderHook callback. Can be useful if you plan
    * to use the rerender utility to change the values passed to your hook.
    */
-  initialProps?: Props | undefined,
-  displayName?: React.FunctionComponent['displayName'],
+  initialProps?: Props | undefined
+  displayName?: React.FunctionComponent['displayName']
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
- Adding a displayName so that if you try to inspect the wrapper component `renderHook` creates, you can (i.e. `console.log`, `useFiber`, `ReactCurrentOwner`)

<!-- Why are these changes necessary? -->

**Why**:
- It's a simple change and makes debugging smoother for those who need it

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
