### PR TITLE
feat: add support for multiple arguments in renderHook()

### DIFF
--- a/src/__tests__/renderHook.js
+++ b/src/__tests__/renderHook.js
@@ -50,6 +50,26 @@ test('allows rerendering', () => {
   expect(result.current).toEqual(['right', expect.any(Function)])
 })
 
+test('allows rerendering with multiple arguments', () => {
+  const useTest = (arg1, arg2, arg3) => arg1 + arg2 + arg3
+  const {result, rerender} = renderHook(useTest, {initialArgs: [2, 3, 4]})
+  expect(result.current).toBe(9)
+  rerender(3, 4, -1)
+  expect(result.current).toBe(6)
+})
+
+test('throws on invalid options', () => {
+  const useTest = (arg1, arg2) => arg1 + arg2
+  expect(() => {
+    renderHook(useTest, {initialProps: {}, initialArgs: []})
+  }).toThrow(
+    'Options `initialProps` and `initialArgs` cannot be used together.',
+  )
+  expect(() => {
+    renderHook(useTest, {initialArgs: {}})
+  }).toThrow('Option `initialArgs` must be an array.')
+})
+
 test('allows wrapper components', async () => {
   const Context = React.createContext('default')
   function Wrapper({children}) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -181,11 +181,12 @@ export function render(
   options?: Omit<RenderOptions, 'queries'> | undefined,
 ): RenderResult
 
-export interface RenderHookResult<Result, Props> {
+export interface RenderHookArgsResult<Result, Args extends any[]> {
   /**
-   * Triggers a re-render. The props will be passed to your renderHook callback.
+   * Triggers a re-render. The arguments will be passed to your renderHook
+   * callback.
    */
-  rerender: (props?: Props) => void
+  rerender: (...args: Args) => void
   /**
    * This is a stable reference to the latest value returned by your renderHook
    * callback
@@ -202,6 +203,11 @@ export interface RenderHookResult<Result, Props> {
    */
   unmount: () => void
 }
+
+export type RenderHookResult<Result, Props> = RenderHookArgsResult<
+  Result,
+  [Props?]
+>
 
 /** @deprecated */
 export type BaseRenderHookOptions<
@@ -256,6 +262,19 @@ export interface RenderHookOptions<
   initialProps?: Props | undefined
 }
 
+export interface RenderHookArgsOptions<
+  Args extends any[],
+  Q extends Queries = typeof queries,
+  Container extends RendererableContainer | HydrateableContainer = HTMLElement,
+  BaseElement extends RendererableContainer | HydrateableContainer = Container,
+> extends RenderOptions<Q, Container, BaseElement> {
+  /**
+   * The argument passed to the renderHook callback. Can be useful if you plan
+   * to use the rerender utility to change the values passed to your hook.
+   */
+  initialArgs: Args
+}
+
 /**
  * Allows you to render a hook within a test React component without having to
  * create that component yourself.
@@ -270,6 +289,21 @@ export function renderHook<
   render: (initialProps: Props) => Result,
   options?: RenderHookOptions<Props, Q, Container, BaseElement> | undefined,
 ): RenderHookResult<Result, Props>
+
+/**
+ * Allows you to render a hook within a test React component without having to
+ * create that component yourself.
+ */
+export function renderHook<
+  Result,
+  Args extends any[],
+  Q extends Queries = typeof queries,
+  Container extends RendererableContainer | HydrateableContainer = HTMLElement,
+  BaseElement extends RendererableContainer | HydrateableContainer = Container,
+>(
+  render: (...initialArgs: Args) => Result,
+  options: RenderHookArgsOptions<Args, Q, Container, BaseElement> | undefined,
+): RenderHookArgsResult<Result, Args>
 
 /**
  * Unmounts React trees that were mounted with render.

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -237,6 +237,16 @@ export function testRenderHookProps() {
   unmount()
 }
 
+export function testRenderHookArgs() {
+  const useTest = (s: string, n: number): string => s.repeat(n)
+  const {result, rerender, unmount} = renderHook(useTest, {
+    initialArgs: ['a', 2],
+  })
+  expectType<string, typeof result.current>(result.current)
+  rerender('b', 3)
+  unmount()
+}
+
 export function testContainer() {
   render('a', {container: document.createElement('div')})
   render('a', {container: document.createDocumentFragment()})


### PR DESCRIPTION

**What**:

Add support for multiple arguments for function `renderHook`. Fixes #1350.

**Why**:

Hooks can take multiple arguments. The current implementation assumes a single argument (derived from `render` taking a single "props" for rendering components).

**How**:

Change renderHook to take a new array option "initialArgs". Option "initialProps" remains in place for backward compat. The options are mutually exclusive.

**Checklist**:

- [ ] Documentation added to the [docs site](https://github.com/testing-library/testing-library-docs)
       (will do that next...)
- [x] Tests
- [x] TypeScript definitions updated
- [x] Ready to be merged

**Comments**:

This is a redo of PR #1386 which lacks correct TS typings, tests for TS typings, and seems to be abandoned.