### PR TITLE
chore(deps): use `npm-run-all2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "dotenv-cli": "^4.0.0",
     "jest-diff": "^29.7.0",
     "kcd-scripts": "^13.0.0",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^6.2.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
[`npm-run-all`](https://npm.im/npm-run-all) is unmaintained and an active & up-to-date fork is now available as [`npm-run-all2`](https://npm.im/npm-run-all2)

---

I'm sure people from the wider @e18e ecosystem cleanup (like @43081j, @benmccann, @Fuzzyma, @outslept & @talentlessguy) will be very happy to see these kind of changes as well