### PR TITLE
[test] Fix `npm run validate`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "npm-run-all --parallel build:main build:bundle:main build:bundle:pure",
-    "build:bundle:main": "dotenv -e .bundle.main.env kcd-scripts build -- --bundle --no-clean",
-    "build:bundle:pure": "dotenv -e .bundle.main.env -e .bundle.pure.env kcd-scripts build -- --bundle --no-clean",
-    "build:main": "kcd-scripts build --no-clean",
+    "build:bundle:main": "dotenv -e .bundle.main.env kcd-scripts build -- --bundle --no-clean --no-ts-defs",
+    "build:bundle:pure": "dotenv -e .bundle.main.env -e .bundle.pure.env kcd-scripts build -- --bundle --no-clean --no-ts-defs",
+    "build:main": "kcd-scripts build --no-clean --no-ts-defs",
     "format": "kcd-scripts format",
     "install:csb": "npm install",
     "lint": "kcd-scripts lint",
     "setup": "npm install && npm run validate -s",
     "test": "kcd-scripts test",
     "test:update": "npm test -- --updateSnapshot --coverage",
-    "typecheck": "kcd-scripts typecheck --build types",
+    "typecheck": "tsc --project tsconfig.json",
     "validate": "kcd-scripts validate"
   },
   "files": [
@@ -60,7 +60,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.1.2"
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "@testing-library/dom": "^10.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,44 @@
+{
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    // File Layout
+    // "rootDir": "./src",
+    // "outDir": "./dist",
+
+    // Environment Settings
+    // See also https://aka.ms/tsconfig/module
+    "module": "nodenext",
+    "target": "esnext",
+    // For nodejs:
+    "lib": ["esnext", "DOM"],
+    "types": ["node"],
+
+    // Other Outputs
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Style Options
+    // "noImplicitReturns": true,
+    // "noImplicitOverride": true,
+    // "noUnusedLocals": true,
+    // "noUnusedParameters": true,
+    // "noFallthroughCasesInSwitch": true,
+    // "noPropertyAccessFromIndexSignature": true,
+
+    "strict": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": false,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": false,
+
+    "noEmit": true
+  },
+  "include": ["types"]
+}


### PR DESCRIPTION
`kcd-scripts` may use a different version of TypeScript since it resolves relative to `kcd-scripts` not the caller. It also uses `--build` which we're not using. Switching to basic `tsc` which makes it easier to reason about what is being used.

Fixes
```
Error: [typecheck] node_modules/@types/node/web-globals/streams.d.ts(10,9): error TS2502: 'CompressionStream' is referenced directly or indirectly in its own type annotation.
```
-- https://github.com/testing-library/react-testing-library/actions/runs/19101381490/job/54573962927?pr=1214 