### PR TITLE
docs: fix typos in comments and types

### DIFF
--- a/src/pure.js
+++ b/src/pure.js
@@ -265,7 +265,7 @@ function render(
   }
 
   let root
-  // eslint-disable-next-line no-negated-condition -- we want to map the evolution of this over time. The root is created first. Only later is it re-used so we don't want to read the case that happens later first.
+  // eslint-disable-next-line no-negated-condition -- we want to map the evolution of this over time. The root is created first. Only later is it reused so we don't want to read the case that happens later first.
   if (!mountedContainers.has(container)) {
     const createRootImpl = legacyRoot ? createLegacyRoot : createConcurrentRoot
     root = createRootImpl(container, {

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -138,7 +138,7 @@ export function wrappedRender(
 
   return pure.render(ui, {
     wrapper: Wrapper,
-    // testing exactOptionalPropertyTypes comaptibility
+    // testing exactOptionalPropertyTypes compatibility
     hydrate: options?.hydrate,
     ...options,
   })


### PR DESCRIPTION
This PR fixes a few minor typographical errors in comments to improve code readability. Found via codespell.