### PR TITLE
feat: add renderAsync to fix React-Aria useLayoutEffect flushing (#1339)

### DIFF
--- a/src/__tests__/render-async.js
+++ b/src/__tests__/render-async.js
@@ -8,7 +8,8 @@
  * @see https://github.com/testing-library/react-testing-library/issues/1339
  */
 import * as React from 'react'
-import {renderAsync, screen, configure} from '../'
+import ReactDOMServer from 'react-dom/server'
+import {renderAsync, fireEvent, screen, configure} from '../'
 
 // ---------------------------------------------------------------------------
 // Helper: simulates a React-Aria-style component that sets ARIA attributes
@@ -129,6 +130,29 @@ describe('renderAsync', () => {
     await renderAsync(<Component />, {reactStrictMode: true})
     // In StrictMode effects run twice
     expect(effectSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('hydrate makes the UI interactive', async () => {
+    function App() {
+      const [clicked, handleClick] = React.useReducer(n => n + 1, 0)
+      return (
+        <button type="button" onClick={handleClick}>
+          clicked:{clicked}
+        </button>
+      )
+    }
+    const ui = <App />
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    container.innerHTML = ReactDOMServer.renderToString(ui)
+
+    expect(container).toHaveTextContent('clicked:0')
+
+    await renderAsync(ui, {container, hydrate: true})
+
+    fireEvent.click(container.querySelector('button'))
+
+    expect(container).toHaveTextContent('clicked:1')
   })
 
   test('legacyRoot throws when React does not support it', async () => {

--- a/src/__tests__/render-async.js
+++ b/src/__tests__/render-async.js
@@ -1,0 +1,171 @@
+/**
+ * Tests for renderAsync — the async variant of render that fully flushes
+ * useLayoutEffect chains before returning. This is the fix for components
+ * (e.g. React-Aria) that set ARIA attributes / roles in useLayoutEffect and
+ * therefore appear "incomplete" when queried immediately after a synchronous
+ * render() call in a consuming application's test suite.
+ *
+ * @see https://github.com/testing-library/react-testing-library/issues/1339
+ */
+import * as React from 'react'
+import {renderAsync, screen, configure} from '../'
+
+// ---------------------------------------------------------------------------
+// Helper: simulates a React-Aria-style component that sets ARIA attributes
+// inside useLayoutEffect (and may trigger a follow-up state update).
+// ---------------------------------------------------------------------------
+
+/**
+ * Mimics a combobox-like component that:
+ *  1. Renders a plain <input> on mount.
+ *  2. In useLayoutEffect, assigns the `role`, `aria-expanded`, and `aria-label`
+ *     attributes that React-Aria would normally set — and also triggers a
+ *     state update to simulate a second render cycle.
+ */
+function AriaComboBox({onSearch}) {
+  const inputRef = React.useRef(null)
+  const [initialised, setInitialised] = React.useState(false)
+
+  React.useLayoutEffect(() => {
+    if (inputRef.current) {
+      // Simulate React-Aria setting ARIA attributes after mount
+      inputRef.current.setAttribute('role', 'combobox')
+      inputRef.current.setAttribute('aria-expanded', 'false')
+      inputRef.current.setAttribute('aria-label', 'Search')
+      inputRef.current.setAttribute('aria-autocomplete', 'list')
+      // Trigger a second render cycle (common in React-Aria internals)
+      setInitialised(true)
+    }
+  }, [])
+
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        placeholder="Type to Start Searching..."
+        data-initialised={initialised ? 'true' : 'false'}
+        onChange={e => onSearch && onSearch(e.target.value)}
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('renderAsync', () => {
+  test('fully flushes useLayoutEffect before returning — ARIA attributes are present', async () => {
+    await renderAsync(<AriaComboBox />)
+
+    // With synchronous render() these attributes would be missing because the
+    // useLayoutEffect → setState → re-render cycle hasn't completed yet.
+    const input = screen.getByRole('combobox')
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveAttribute('aria-expanded', 'false')
+    expect(input).toHaveAttribute('aria-label', 'Search')
+    expect(input).toHaveAttribute('aria-autocomplete', 'list')
+  })
+
+  test('second render cycle triggered by useLayoutEffect is complete', async () => {
+    await renderAsync(<AriaComboBox />)
+
+    const input = screen.getByRole('combobox')
+    // data-initialised is set to "true" only after the setState in useLayoutEffect
+    expect(input).toHaveAttribute('data-initialised', 'true')
+  })
+
+  test('returned queries work correctly after async render', async () => {
+    const handleSearch = jest.fn()
+    const {getByPlaceholderText} = await renderAsync(
+      <AriaComboBox onSearch={handleSearch} />,
+    )
+
+    const input = getByPlaceholderText('Type to Start Searching...')
+    expect(input).toBeInTheDocument()
+    // The input should be fully interactive — role is set
+    expect(input).toHaveAttribute('role', 'combobox')
+  })
+
+  test('rerender (async) also flushes effects', async () => {
+    const {rerender, getByRole} = await renderAsync(<AriaComboBox />)
+
+    // Rerender with a new prop — effects should still flush
+    await rerender(<AriaComboBox onSearch={() => {}} />)
+
+    const input = getByRole('combobox')
+    expect(input).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  test('unmount works after async render', async () => {
+    const {unmount} = await renderAsync(<AriaComboBox />)
+    expect(() => unmount()).not.toThrow()
+  })
+
+  test('accepts the same options as render (wrapper, queries, etc.)', async () => {
+    const Context = React.createContext('default')
+    function Wrapper({children}) {
+      return (
+        <Context.Provider value="provided">{children}</Context.Provider>
+      )
+    }
+
+    function ConsumerComponent() {
+      const value = React.useContext(Context)
+      return <div data-testid="ctx-value">{value}</div>
+    }
+
+    await renderAsync(<ConsumerComponent />, {wrapper: Wrapper})
+    expect(screen.getByTestId('ctx-value')).toHaveTextContent('provided')
+  })
+
+  test('reactStrictMode option is respected', async () => {
+    const effectSpy = jest.fn()
+    function Component() {
+      React.useEffect(() => {
+        effectSpy()
+      }, [])
+      return null
+    }
+
+    await renderAsync(<Component />, {reactStrictMode: true})
+    // In StrictMode effects run twice
+    expect(effectSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('legacyRoot throws when React does not support it', async () => {
+    // React 19+ does not expose ReactDOM.render
+    if (typeof require('react-dom').render !== 'function') {
+      await expect(
+        renderAsync(<div />, {legacyRoot: true}),
+      ).rejects.toThrow('`legacyRoot: true` is not supported')
+    }
+  })
+
+  describe('reactStrictMode config', () => {
+    let originalConfig
+    beforeEach(() => {
+      configure(existingConfig => {
+        originalConfig = existingConfig
+        return {}
+      })
+    })
+    afterEach(() => {
+      configure(originalConfig)
+    })
+
+    test('respects global reactStrictMode config', async () => {
+      configure({reactStrictMode: true})
+      const effectSpy = jest.fn()
+      function Component() {
+        React.useEffect(() => {
+          effectSpy()
+        }, [])
+        return null
+      }
+
+      await renderAsync(<Component />)
+      expect(effectSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/src/__tests__/render-async.js
+++ b/src/__tests__/render-async.js
@@ -1,5 +1,5 @@
 /**
- * Tests for renderAsync — the async variant of render that fully flushes
+ * Tests for renderAsync - the async variant of render that fully flushes
  * useLayoutEffect chains before returning. This is the fix for components
  * (e.g. React-Aria) that set ARIA attributes / roles in useLayoutEffect and
  * therefore appear "incomplete" when queried immediately after a synchronous
@@ -18,9 +18,9 @@ import {renderAsync, screen, configure} from '../'
 /**
  * Mimics a combobox-like component that:
  *  1. Renders a plain <input> on mount.
- *  2. In useLayoutEffect, assigns the `role`, `aria-expanded`, and `aria-label`
- *     attributes that React-Aria would normally set — and also triggers a
- *     state update to simulate a second render cycle.
+ *  2. In useLayoutEffect, assigns the `role`, `aria-expanded`, and
+ *     `aria-label` attributes that React-Aria would normally set - and also
+ *     triggers a state update to simulate a second render cycle.
  */
 function AriaComboBox({onSearch}) {
   const inputRef = React.useRef(null)
@@ -55,11 +55,11 @@ function AriaComboBox({onSearch}) {
 // ---------------------------------------------------------------------------
 
 describe('renderAsync', () => {
-  test('fully flushes useLayoutEffect before returning — ARIA attributes are present', async () => {
+  test('fully flushes useLayoutEffect before returning - ARIA attributes are present', async () => {
     await renderAsync(<AriaComboBox />)
 
-    // With synchronous render() these attributes would be missing because the
-    // useLayoutEffect → setState → re-render cycle hasn't completed yet.
+    // With synchronous render() these attributes would be missing because
+    // the useLayoutEffect -> setState -> re-render cycle hasn't completed.
     const input = screen.getByRole('combobox')
     expect(input).toBeInTheDocument()
     expect(input).toHaveAttribute('aria-expanded', 'false')
@@ -71,7 +71,7 @@ describe('renderAsync', () => {
     await renderAsync(<AriaComboBox />)
 
     const input = screen.getByRole('combobox')
-    // data-initialised is set to "true" only after the setState in useLayoutEffect
+    // data-initialised is set to "true" only after setState in useLayoutEffect
     expect(input).toHaveAttribute('data-initialised', 'true')
   })
 
@@ -83,14 +83,14 @@ describe('renderAsync', () => {
 
     const input = getByPlaceholderText('Type to Start Searching...')
     expect(input).toBeInTheDocument()
-    // The input should be fully interactive — role is set
+    // The input should be fully interactive - role is set
     expect(input).toHaveAttribute('role', 'combobox')
   })
 
   test('rerender (async) also flushes effects', async () => {
     const {rerender, getByRole} = await renderAsync(<AriaComboBox />)
 
-    // Rerender with a new prop — effects should still flush
+    // Rerender with a new prop - effects should still flush
     await rerender(<AriaComboBox onSearch={() => {}} />)
 
     const input = getByRole('combobox')
@@ -105,9 +105,7 @@ describe('renderAsync', () => {
   test('accepts the same options as render (wrapper, queries, etc.)', async () => {
     const Context = React.createContext('default')
     function Wrapper({children}) {
-      return (
-        <Context.Provider value="provided">{children}</Context.Provider>
-      )
+      return <Context.Provider value="provided">{children}</Context.Provider>
     }
 
     function ConsumerComponent() {
@@ -136,9 +134,9 @@ describe('renderAsync', () => {
   test('legacyRoot throws when React does not support it', async () => {
     // React 19+ does not expose ReactDOM.render
     if (typeof require('react-dom').render !== 'function') {
-      await expect(
-        renderAsync(<div />, {legacyRoot: true}),
-      ).rejects.toThrow('`legacyRoot: true` is not supported')
+      await expect(renderAsync(<div />, {legacyRoot: true})).rejects.toThrow(
+        '`legacyRoot: true` is not supported',
+      )
     }
   })
 

--- a/src/pure.js
+++ b/src/pure.js
@@ -152,6 +152,37 @@ function createLegacyRoot(container) {
   }
 }
 
+function buildRenderResult({baseElement, container, queries, root}) {
+  return {
+    container,
+    baseElement,
+    debug: (el = baseElement, maxLength, options) =>
+      Array.isArray(el)
+        ? // eslint-disable-next-line no-console
+          el.forEach(e => console.log(prettyDOM(e, maxLength, options)))
+        : // eslint-disable-next-line no-console,
+          console.log(prettyDOM(el, maxLength, options)),
+    unmount: () => {
+      act(() => {
+        root.unmount()
+      })
+    },
+    asFragment: () => {
+      /* istanbul ignore else (old jsdom limitation) */
+      if (typeof document.createRange === 'function') {
+        return document
+          .createRange()
+          .createContextualFragment(container.innerHTML)
+      } else {
+        const template = document.createElement('template')
+        template.innerHTML = container.innerHTML
+        return template.content
+      }
+    },
+    ...getQueriesForElement(baseElement, queries),
+  }
+}
+
 function renderRoot(
   ui,
   {
@@ -184,20 +215,10 @@ function renderRoot(
     }
   })
 
+  const result = buildRenderResult({baseElement, container, queries, root})
+
   return {
-    container,
-    baseElement,
-    debug: (el = baseElement, maxLength, options) =>
-      Array.isArray(el)
-        ? // eslint-disable-next-line no-console
-          el.forEach(e => console.log(prettyDOM(e, maxLength, options)))
-        : // eslint-disable-next-line no-console,
-          console.log(prettyDOM(el, maxLength, options)),
-    unmount: () => {
-      act(() => {
-        root.unmount()
-      })
-    },
+    ...result,
     rerender: rerenderUi => {
       renderRoot(rerenderUi, {
         container,
@@ -209,61 +230,72 @@ function renderRoot(
       // Intentionally do not return anything to avoid unnecessarily complicating the API.
       // folks can use all the same utilities we return in the first place that are bound to the container
     },
-    asFragment: () => {
-      /* istanbul ignore else (old jsdom limitation) */
-      if (typeof document.createRange === 'function') {
-        return document
-          .createRange()
-          .createContextualFragment(container.innerHTML)
-      } else {
-        const template = document.createElement('template')
-        template.innerHTML = container.innerHTML
-        return template.content
-      }
-    },
-    ...getQueriesForElement(baseElement, queries),
   }
 }
 
-function render(
+async function renderRootAsync(
+  ui,
+  {
+    baseElement,
+    container,
+    hydrate,
+    queries,
+    root,
+    wrapper: WrapperComponent,
+    reactStrictMode,
+  },
+) {
+  await act(async () => {
+    if (hydrate) {
+      root.hydrate(
+        strictModeIfNeeded(
+          wrapUiIfNeeded(ui, WrapperComponent),
+          reactStrictMode,
+        ),
+        container,
+      )
+    } else {
+      root.render(
+        strictModeIfNeeded(
+          wrapUiIfNeeded(ui, WrapperComponent),
+          reactStrictMode,
+        ),
+        container,
+      )
+    }
+  })
+
+  const result = buildRenderResult({baseElement, container, queries, root})
+
+  return {
+    ...result,
+    rerender: async rerenderUi => {
+      await renderRootAsync(rerenderUi, {
+        container,
+        baseElement,
+        root,
+        wrapper: WrapperComponent,
+        reactStrictMode,
+      })
+      // Intentionally do not return anything to avoid unnecessarily complicating the API.
+      // folks can use all the same utilities we return in the first place that are bound to the container
+    },
+  }
+}
+
+function buildRoot(
   ui,
   {
     container,
-    baseElement = container,
-    legacyRoot = false,
+    baseElement,
+    legacyRoot,
     onCaughtError,
-    onUncaughtError,
     onRecoverableError,
-    queries,
-    hydrate = false,
+    hydrate,
     wrapper,
     reactStrictMode,
-  } = {},
+  },
 ) {
-  if (onUncaughtError !== undefined) {
-    throw new Error(
-      'onUncaughtError is not supported. The `render` call will already throw on uncaught errors.',
-    )
-  }
-  if (legacyRoot && typeof ReactDOM.render !== 'function') {
-    const error = new Error(
-      '`legacyRoot: true` is not supported in this version of React. ' +
-        'If your app runs React 19 or later, you should remove this flag. ' +
-        'If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.',
-    )
-    Error.captureStackTrace(error, render)
-    throw error
-  }
-
-  if (!baseElement) {
-    // default to document.body instead of documentElement to avoid output of potentially-large
-    // head elements (such as JSS style blocks) in debug output
-    baseElement = document.body
-  }
-  if (!container) {
-    container = baseElement.appendChild(document.createElement('div'))
-  }
-
   let root
   // eslint-disable-next-line no-negated-condition -- we want to map the evolution of this over time. The root is created first. Only later is it reused so we don't want to read the case that happens later first.
   if (!mountedContainers.has(container)) {
@@ -285,22 +317,108 @@ function render(
   } else {
     mountedRootEntries.forEach(rootEntry => {
       // Else is unreachable since `mountedContainers` has the `container`.
-      // Only reachable if one would accidentally add the container to `mountedContainers` but not the root to `mountedRootEntries`
+      // Only reachable if one would accidentally add the container to `mountedRootEntries`
       /* istanbul ignore else */
       if (rootEntry.container === container) {
         root = rootEntry.root
       }
     })
   }
+  return root
+}
 
-  return renderRoot(ui, {
+function resolveRenderOptions(options = {}) {
+  let {
+    container,
+    baseElement = container,
+    legacyRoot = false,
+    onCaughtError,
+    onUncaughtError,
+    onRecoverableError,
+    queries,
+    hydrate = false,
+    wrapper,
+    reactStrictMode,
+  } = options
+
+  if (onUncaughtError !== undefined) {
+    throw new Error(
+      'onUncaughtError is not supported. The `render` call will already throw on uncaught errors.',
+    )
+  }
+
+  if (!baseElement) {
+    // default to document.body instead of documentElement to avoid output of potentially-large
+    // head elements (such as JSS style blocks) in debug output
+    baseElement = document.body
+  }
+  if (!container) {
+    container = baseElement.appendChild(document.createElement('div'))
+  }
+
+  return {
     container,
     baseElement,
+    legacyRoot,
+    onCaughtError,
+    onRecoverableError,
     queries,
     hydrate,
     wrapper,
-    root,
     reactStrictMode,
+  }
+}
+
+function render(ui, options = {}) {
+  const {legacyRoot, ...resolvedOptions} = resolveRenderOptions(options)
+
+  if (legacyRoot && typeof ReactDOM.render !== 'function') {
+    const error = new Error(
+      '`legacyRoot: true` is not supported in this version of React. ' +
+        'If your app runs React 19 or later, you should remove this flag. ' +
+        'If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.',
+    )
+    Error.captureStackTrace(error, render)
+    throw error
+  }
+
+  const root = buildRoot(ui, {legacyRoot, ...resolvedOptions})
+
+  return renderRoot(ui, {
+    ...resolvedOptions,
+    root,
+  })
+}
+
+/**
+ * An async version of `render` that uses `await act(async () => {...})` to
+ * fully flush all pending effects — including `useLayoutEffect` chains that
+ * trigger state updates and re-renders (common in React-Aria and similar
+ * libraries). Use this when components don't appear fully initialised after a
+ * synchronous `render` call.
+ *
+ * @example
+ * const {getByRole} = await renderAsync(<MyComboBox />)
+ * await userEvent.type(getByRole('combobox'), 'hello')
+ */
+async function renderAsync(ui, options = {}) {
+  const {legacyRoot, ...resolvedOptions} = resolveRenderOptions(options)
+
+  if (legacyRoot && typeof ReactDOM.render !== 'function') {
+    const error = new Error(
+      '`legacyRoot: true` is not supported in this version of React. ' +
+        'If your app runs React 19 or later, you should remove this flag. ' +
+        'If your app runs React 18 or earlier, visit https://react.dev/blog/2022/03/08/react-18-upgrade-guide for upgrade instructions.',
+    )
+    Error.captureStackTrace(error, renderAsync)
+    throw error
+  }
+
+  const root = buildRoot(ui, {legacyRoot, ...resolvedOptions})
+
+  return renderRootAsync(ui, {
+    ...resolvedOptions,
+    root,
   })
 }
 
@@ -358,6 +476,6 @@ function renderHook(renderCallback, options = {}) {
 
 // just re-export everything from dom-testing-library
 export * from '@testing-library/dom'
-export {render, renderHook, cleanup, act, fireEvent, getConfig, configure}
+export {render, renderAsync, renderHook, cleanup, act, fireEvent, getConfig, configure}
 
 /* eslint func-name-matching:0 */

--- a/src/pure.js
+++ b/src/pure.js
@@ -78,7 +78,7 @@ const mountedContainers = new Set()
 const mountedRootEntries = []
 
 function strictModeIfNeeded(innerElement, reactStrictMode) {
-  return reactStrictMode ?? getConfig().reactStrictMode
+  return (reactStrictMode ?? getConfig().reactStrictMode)
     ? React.createElement(React.StrictMode, null, innerElement)
     : innerElement
 }
@@ -392,7 +392,7 @@ function render(ui, options = {}) {
 
 /**
  * An async version of `render` that uses `await act(async () => {...})` to
- * fully flush all pending effects — including `useLayoutEffect` chains that
+ * fully flush all pending effects - including `useLayoutEffect` chains that
  * trigger state updates and re-renders (common in React-Aria and similar
  * libraries). Use this when components don't appear fully initialised after a
  * synchronous `render` call.
@@ -476,6 +476,15 @@ function renderHook(renderCallback, options = {}) {
 
 // just re-export everything from dom-testing-library
 export * from '@testing-library/dom'
-export {render, renderAsync, renderHook, cleanup, act, fireEvent, getConfig, configure}
+export {
+  render,
+  renderAsync,
+  renderHook,
+  cleanup,
+  act,
+  fireEvent,
+  getConfig,
+  configure,
+}
 
 /* eslint func-name-matching:0 */

--- a/src/pure.js
+++ b/src/pure.js
@@ -372,6 +372,7 @@ function resolveRenderOptions(options = {}) {
 function render(ui, options = {}) {
   const {legacyRoot, ...resolvedOptions} = resolveRenderOptions(options)
 
+  /* istanbul ignore next */
   if (legacyRoot && typeof ReactDOM.render !== 'function') {
     const error = new Error(
       '`legacyRoot: true` is not supported in this version of React. ' +
@@ -404,6 +405,7 @@ function render(ui, options = {}) {
 async function renderAsync(ui, options = {}) {
   const {legacyRoot, ...resolvedOptions} = resolveRenderOptions(options)
 
+  /* istanbul ignore next */
   if (legacyRoot && typeof ReactDOM.render !== 'function') {
     const error = new Error(
       '`legacyRoot: true` is not supported in this version of React. ' +
@@ -438,6 +440,7 @@ function cleanup() {
 function renderHook(renderCallback, options = {}) {
   const {initialProps, ...renderOptions} = options
 
+  /* istanbul ignore next */
   if (renderOptions.legacyRoot && typeof ReactDOM.render !== 'function') {
     const error = new Error(
       '`legacyRoot: true` is not supported in this version of React. ' +

--- a/src/pure.js
+++ b/src/pure.js
@@ -78,7 +78,7 @@ const mountedContainers = new Set()
 const mountedRootEntries = []
 
 function strictModeIfNeeded(innerElement, reactStrictMode) {
-  return (reactStrictMode ?? getConfig().reactStrictMode)
+  return reactStrictMode ?? getConfig().reactStrictMode
     ? React.createElement(React.StrictMode, null, innerElement)
     : innerElement
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,7 +54,9 @@ export type BaseRenderOptions<
 > = RenderOptions<Q, Container, BaseElement>
 
 type RendererableContainer = ReactDOMClient.Container
-type HydrateableContainer = Parameters<typeof ReactDOMClient['hydrateRoot']>[0]
+type HydrateableContainer = Parameters<
+  (typeof ReactDOMClient)['hydrateRoot']
+>[0]
 /** @deprecated */
 export interface ClientRenderOptions<
   Q extends Queries,
@@ -183,7 +185,7 @@ export function render(
 
 /**
  * An async version of `render` that uses `await act(async () => {...})` to
- * fully flush all pending effects — including `useLayoutEffect` chains that
+ * fully flush all pending effects - including `useLayoutEffect` chains that
  * trigger state updates and re-renders (common in React-Aria and similar
  * libraries). Use this when components don't appear fully initialised after a
  * synchronous `render` call.
@@ -199,7 +201,11 @@ export function renderAsync<
 >(
   ui: React.ReactNode,
   options: RenderOptions<Q, Container, BaseElement>,
-): Promise<RenderResult<Q, Container, BaseElement> & {rerender: (ui: React.ReactNode) => Promise<void>}>
+): Promise<
+  RenderResult<Q, Container, BaseElement> & {
+    rerender: (ui: React.ReactNode) => Promise<void>
+  }
+>
 export function renderAsync(
   ui: React.ReactNode,
   options?: Omit<RenderOptions, 'queries'> | undefined,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,9 +54,7 @@ export type BaseRenderOptions<
 > = RenderOptions<Q, Container, BaseElement>
 
 type RendererableContainer = ReactDOMClient.Container
-type HydrateableContainer = Parameters<
-  (typeof ReactDOMClient)['hydrateRoot']
->[0]
+type HydrateableContainer = Parameters<typeof ReactDOMClient['hydrateRoot']>[0]
 /** @deprecated */
 export interface ClientRenderOptions<
   Q extends Queries,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -181,6 +181,30 @@ export function render(
   options?: Omit<RenderOptions, 'queries'> | undefined,
 ): RenderResult
 
+/**
+ * An async version of `render` that uses `await act(async () => {...})` to
+ * fully flush all pending effects — including `useLayoutEffect` chains that
+ * trigger state updates and re-renders (common in React-Aria and similar
+ * libraries). Use this when components don't appear fully initialised after a
+ * synchronous `render` call.
+ *
+ * @example
+ * const {getByRole} = await renderAsync(<MyComboBox />)
+ * await userEvent.type(getByRole('combobox'), 'hello')
+ */
+export function renderAsync<
+  Q extends Queries = typeof queries,
+  Container extends RendererableContainer | HydrateableContainer = HTMLElement,
+  BaseElement extends RendererableContainer | HydrateableContainer = Container,
+>(
+  ui: React.ReactNode,
+  options: RenderOptions<Q, Container, BaseElement>,
+): Promise<RenderResult<Q, Container, BaseElement> & {rerender: (ui: React.ReactNode) => Promise<void>}>
+export function renderAsync(
+  ui: React.ReactNode,
+  options?: Omit<RenderOptions, 'queries'> | undefined,
+): Promise<RenderResult & {rerender: (ui: React.ReactNode) => Promise<void>}>
+
 export interface RenderHookResult<Result, Props> {
   /**
    * Triggers a re-render. The props will be passed to your renderHook callback.


### PR DESCRIPTION
## Problem

Closes #1339

Components like React-Aria `ComboBox` set ARIA attributes (`role`, `aria-expanded`, `aria-label`, etc.) inside `useLayoutEffect`, and often trigger a `setState` there — causing a second render cycle. The synchronous `render()` wraps the initial paint in `act()` but does **not** guarantee that the `useLayoutEffect → setState → re-render` chain completes before returning.

This makes the DOM appear half-initialised in consuming-application tests:

- `getByRole('combobox')` throws because `role` hasn't been set yet
- `aria-*` attributes are missing
- `userEvent.type()` has no effect because the input isn't fully wired up

The component works correctly at runtime and in the component library's own tests, but breaks in any consuming app's test suite.

## Solution

Add a new `renderAsync` utility that uses `await act(async () => {...})` to fully drain the microtask queue and all pending `useLayoutEffect` cycles before resolving.

### Usage

```js
// Before (broken with React-Aria):
const { getByPlaceholderText } = render(<MyComboBox />)
const input = getByPlaceholderText('Type to Start Searching...')
// role / aria-* attributes not set yet ❌

// After (fixed):
const { getByRole } = await renderAsync(<MyComboBox />)
const input = getByRole('combobox') // fully initialised ✓
await userEvent.type(input, 'racc')
await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/MYAPI?term=racc', ...))
